### PR TITLE
Revamped ScriptTests by adding ScriptTest utility class

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -128,6 +128,7 @@
     <Compile Include="ParameterParsingTests\SelectorLogicParameterProcessorTests.cs" />
     <Compile Include="ParameterParsingTests\SimpleCommandProcessorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ScriptTests\ScriptTest.cs" />
     <Compile Include="ScriptTests\SimpleCommandExecutionTests.cs" />
     <Compile Include="ScriptTests\SimpleBlockCommandTests.cs" />
     <Compile Include="TokenParsingTests\StringParsingTests.cs" />

--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -133,6 +133,7 @@
     <Compile Include="ScriptTests\SimpleBlockCommandTests.cs" />
     <Compile Include="TokenParsingTests\StringParsingTests.cs" />
     <Compile Include="TokenParsingTests\ParenthesisParsingTests.cs" />
+    <Compile Include="Util\Extensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Instructions.readme" />

--- a/EasyCommands.Tests/ScriptTests/ConditionalBlockExecutionTests.cs
+++ b/EasyCommands.Tests/ScriptTests/ConditionalBlockExecutionTests.cs
@@ -35,7 +35,7 @@ namespace EasyCommands.Tests.ScriptTests
                 test.MockBlocksOfType("rover cockpit", mockRoverCockpit);
                 test.MockBlocksInGroup("reverse sirens", mockReverseSirens);
 
-                test.RunUntil(Program.ProgramState.COMPLETE);
+                test.RunUntilDone();
 
                 mockReverseSirens.Verify(b => b.Play(), Times.Once);
             }

--- a/EasyCommands.Tests/ScriptTests/ScriptTest.cs
+++ b/EasyCommands.Tests/ScriptTests/ScriptTest.cs
@@ -1,0 +1,182 @@
+﻿using IngameScript;
+using Malware.MDKUtilities;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static IngameScript.Program;
+
+namespace EasyCommands.Tests.ScriptTests
+{
+    /// <summary>
+    /// Represents an instance of a ScriptTest. Constructing a new ScriptTest is akin to setting
+    /// up the test, as it instantiates required objects and performs basic setup.
+    /// 
+    /// This implements <see cref="IDisposable"/>, so any post-test cleanup is performed
+    /// upon destruction of the class. Please use this inside of a using statement.
+    /// </summary>
+    class ScriptTest : IDisposable
+    {
+        private GenericListDictionary mockedBlocksByName;
+        private List<IMyBlockGroup> mockedGroups;
+        private Mock<IMyGridTerminalSystem> gridMock;
+        private Program program;
+
+        public List<String> Logger { get; private set; }
+
+        public ScriptTest(String script)
+        {
+            mockedBlocksByName = new GenericListDictionary();
+            mockedGroups = new List<IMyBlockGroup>();
+            Logger = new List<String>();
+
+            // Init static fields that may have been modified from other tests, prepare for testing
+            Program.STATE = ProgramState.STOPPED;
+            Program.LOG_LEVEL = Program.LogLevel.SCRIPT_ONLY;
+            // Setup the CUSTOM_DATA to return the given script
+            // And other required config for mocking
+            gridMock = new Mock<IMyGridTerminalSystem>();
+            var me = new Mock<IMyProgrammableBlock>();
+            MDKFactory.ProgramConfig config = default;
+            config.GridTerminalSystem = gridMock.Object;
+            config.ProgrammableBlock = me.Object;
+            config.Echo = (message) => Logger.Add(message);
+            program = MDKFactory.CreateProgram<Program>(config);
+            me.Setup(b => b.CustomData).Returns(script);
+
+            // Default behavior for broadcast messages
+            // TODO: Replace this with mock objects passed to config setup in Program
+            program.broadcastMessageProvider = () => new List<MyIGCMessage>();
+
+            // Default behavior for locating blocks on the grid
+            gridMock.Setup(g => g.GetBlockGroups(It.IsAny<List<IMyBlockGroup>>(), It.IsAny<Func<IMyBlockGroup, bool>>()))
+                .Callback((Action<List<IMyBlockGroup>, Func<IMyBlockGroup, bool>>)GetBlockGroupsCallback);
+
+            // TODO: Handle custom logic in TextSurfaceHandler
+        }
+
+        /// <summary>
+        /// Run the script until the program reaches the specified state, or until a limited
+        /// number of runs has been reached. The default number of runs before exit is 100.
+        /// </summary>
+        /// <param name="state">The desired end-state.</param>
+        /// <param name="runLimit">The limited number of runs. Defaults to 100</param>
+        public void RunUntil(ProgramState state, int runLimit = 100)
+        {
+            int runCounter = 0;
+            do
+            {
+                MDKFactory.Run(program);
+                runCounter++;
+            } while (Program.STATE != state && runCounter < runLimit);
+        }
+
+        /// <summary>
+        /// Given a custom name for a block (or set of blocks), set up the custom names
+        /// for the given mocked blocks and store them for later retrieval when requested by
+        /// the grid terminal system.
+        /// 
+        /// Since the GridTerminalSystem's GetBlocksOfType method doesn't return values but
+        /// instead modifies the given list, this uses Moq's Callback functionality to
+        /// invoke a callback that will attempt to retrieve the stored blocks.
+        /// </summary>
+        /// <typeparam name="T">The type of the blocks we're mocking retrieval for.</typeparam>
+        /// <param name="name">The custom name of the block(s) we're mocking.</param>
+        /// <param name="blockMocks">Blocked mocks to be stored and used later.</param>
+        public void MockBlocksOfType<T>(String name, params Mock<T>[] blockMocks) where T : class, IMyTerminalBlock
+        {
+            SetupMockBlocksByType(name, blockMocks);
+
+            // Set up the mocked GridTerminalSystem to invoke the appropriate callback method for the appropriate type
+            gridMock.Setup(g => g.GetBlocksOfType(It.IsAny<List<T>>(), It.IsAny<Func<T, bool>>()))
+                .Callback((Action<List<T>, Func<T, bool>>)GetBlocksOfTypeCallback);
+        }
+
+        /// <summary>
+        /// Given a group name, set up a mock group that will be retrieved by the GridTerminalSystem.
+        /// Store the given mocked blocks for later retrieval.
+        /// 
+        /// Also, set up the group's GetBlocksOfType method to use a Moq Callback so that
+        /// those mocked blocks can be found later.
+        /// </summary>
+        /// <typeparam name="T">The type of the blocks being mocked for this group.</typeparam>
+        /// <param name="groupName">The name of the group being mocked.</param>
+        /// <param name="blockMocks">The blocks being mocked and that will be returned later.</param>
+        public void MockBlocksInGroup<T>(String groupName, params Mock<T>[] blockMocks) where T : class, IMyTerminalBlock
+        {
+            var mockGroup = new Mock<IMyBlockGroup>();
+            mockGroup.Setup(g => g.Name).Returns(groupName);
+            mockGroup.Setup(g => g.GetBlocksOfType(It.IsAny<List<T>>(), It.IsAny<Func<T, bool>>()))
+                .Callback((Action<List<T>, Func<T, bool>>)GetBlocksOfTypeCallback);
+            mockedGroups.Add(mockGroup.Object);
+
+            SetupMockBlocksByType(blockMocks);
+        }
+
+        private void GetBlocksOfTypeCallback<T>(List<T> blocks, Func<T, bool> collect) where T : class, IMyTerminalBlock
+        {
+            // Find the appropriate blocks by type and then invoke the given collector function on them as a filter
+            blocks.AddRange(mockedBlocksByName.GetValue<T>(typeof(T))
+                .Select(x => x)
+                .Where(collect != null ? collect : (x) => true)
+                .ToList());
+        }
+
+        private void GetBlockGroupsCallback(List<IMyBlockGroup> groups, Func<IMyBlockGroup, bool> collect)
+        {
+            // Invoke the given collector function on all groups and return those groups matching
+            groups.AddRange(mockedGroups
+                .Select(x => x)
+                .Where(collect != null ? collect : (x) => true)
+                .ToList());
+        }
+
+        public void Dispose()
+        {
+            // TODO: Unset any static changes, etc
+            Program.STATE = ProgramState.STOPPED;
+            Program.LOG_LEVEL = LogLevel.INFO;
+        }
+
+        private void SetupMockBlocksByType<T>(string name, Mock<T>[] blockMocks) where T : class, IMyTerminalBlock
+        {
+            // Setup the mock blocks to mock their custom name to match the name provided
+            List<T> blockObjects = blockMocks.Select(b =>
+            {
+                b.Setup(x => x.CustomName).Returns(name);
+                return b.Object;
+            }).ToList();
+            // Store the mock block objects by their type
+            mockedBlocksByName.Add(typeof(T), blockObjects);
+        }
+
+        private void SetupMockBlocksByType<T>(Mock<T>[] blockMocks) where T: class, IMyTerminalBlock
+        {
+            // Store the mock block objects by their type
+            mockedBlocksByName.Add(typeof(T), blockMocks.Select(b => b.Object).ToList());
+        }
+
+        public class GenericListDictionary
+        {
+            private Dictionary<Type, List<Object>> dictionary = new Dictionary<Type, List<object>>();
+
+            public void Add<T>(Type type, List<T> values)
+            {
+                dictionary.Add(type, values.Select(x => (Object)x).ToList());
+            }
+
+            public List<T> GetValue<T>(Type type)
+            {
+                if (!dictionary.ContainsKey(type))
+                {
+                    return new List<T>();
+                }
+
+                return dictionary[type].Select(x => (T)x).ToList();
+            }
+        }
+    }
+}

--- a/EasyCommands.Tests/ScriptTests/SimpleBlockCommandTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleBlockCommandTests.cs
@@ -15,12 +15,6 @@ namespace EasyCommands.Tests.ScriptTests
         [TestMethod]
         public void LightBlockHandlerTest()
         {
-            var me = new Mock<IMyProgrammableBlock>();
-            MDKFactory.ProgramConfig config = default;
-            config.ProgrammableBlock = me.Object;
-
-            var program = MDKFactory.CreateProgram<Program>(config);
-            int numCommandsInScript = 7;
             String script = @"
 :lightshow
 set the ""cool light"" color to ""blue""
@@ -32,39 +26,21 @@ set the ""cool light"" blinkLength to 2
 turn on the ""cool light""
 ";
 
-            me.Setup(b => b.CustomData).Returns(script);
+            using (ScriptTest test = new ScriptTest(script))
+            {
+                var mockLight = new Mock<IMyLightingBlock>();
+                test.MockBlocksOfType("cool light", mockLight);
 
-            var mockLight = new Mock<IMyLightingBlock>();
-            //TODO: Replace these with mock objects passed to config setup in Program.
-            Program.BROADCAST_MESSAGE_PROVIDER = (x) => new List<MyIGCMessage>();
-            Program.BlockHandlerRegistry.BLOCK_PROVIDER = (blockType, name) =>
-            {
-                var blocks = new List<Object>();
-                if (blockType.Equals(Program.BlockType.LIGHT) && name.Equals("cool light"))
-                {
-                    blocks.Add(mockLight.Object);
-                }
-                return blocks;
-            };
-            Program.BlockHandlerRegistry.GROUP_BLOCK_PROVIDER = (blockType, name) =>
-            {
-                return new List<object>();
-            };
+                test.RunUntil(Program.ProgramState.COMPLETE);
 
-            // Seven commands in the script, so we need to run the program seven times
-            for (int i = 0; i < numCommandsInScript; i++)
-            {
-                MDKFactory.Run(program);
+                mockLight.VerifySet(b => b.Color = new Color(0, 0, 255));
+                mockLight.VerifySet(b => b.Intensity = 10f);
+                mockLight.VerifySet(b => b.BlinkIntervalSeconds = 0.5f);
+                mockLight.VerifySet(b => b.BlinkOffset = 0.25f);
+                mockLight.VerifySet(b => b.Falloff = 1);
+                mockLight.VerifySet(b => b.BlinkLength = 2);
+                mockLight.VerifySet(b => b.Enabled = true);
             }
-
-            mockLight.VerifySet(b => b.Color = new Color(0, 0, 255));
-            mockLight.VerifySet(b => b.Intensity = 10f);
-            mockLight.VerifySet(b => b.BlinkIntervalSeconds = 0.5f);
-            mockLight.VerifySet(b => b.BlinkOffset = 0.25f);
-            mockLight.VerifySet(b => b.Falloff = 1);
-            mockLight.VerifySet(b => b.BlinkLength = 2);
-            mockLight.VerifySet(b => b.Enabled = true);
-
         }
     }
 }

--- a/EasyCommands.Tests/ScriptTests/SimpleBlockCommandTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleBlockCommandTests.cs
@@ -31,7 +31,7 @@ turn on the ""cool light""
                 var mockLight = new Mock<IMyLightingBlock>();
                 test.MockBlocksOfType("cool light", mockLight);
 
-                test.RunUntil(Program.ProgramState.COMPLETE);
+                test.RunUntilDone();
 
                 mockLight.VerifySet(b => b.Color = new Color(0, 0, 255));
                 mockLight.VerifySet(b => b.Intensity = 10f);
@@ -40,6 +40,79 @@ turn on the ""cool light""
                 mockLight.VerifySet(b => b.Falloff = 1);
                 mockLight.VerifySet(b => b.BlinkLength = 2);
                 mockLight.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void MultipleBlocksSameType()
+        {
+            String script = @"
+:lightshow
+set the ""intense light"" intensity to 10
+set the ""intense light"" blinkInterval to 0.5
+set the ""intense light"" blinkOffset to 0.25
+set the ""intense light"" blinkLength to 2
+set the ""cool light"" color to ""blue""
+set the ""cool light"" falloff to 1
+turn on the ""cool light""
+turn on the ""intense light""
+";
+
+            using (ScriptTest test = new ScriptTest(script))
+            {
+                var mockCoolLight = new Mock<IMyLightingBlock>();
+                var mockIntenseLight = new Mock<IMyLightingBlock>();
+                test.MockBlocksOfType("cool light", mockCoolLight);
+                test.MockBlocksOfType("intense light", mockIntenseLight);
+
+                test.RunUntilDone();
+
+                mockIntenseLight.VerifySet(b => b.Intensity = 10f);
+                mockIntenseLight.VerifySet(b => b.BlinkIntervalSeconds = 0.5f);
+                mockIntenseLight.VerifySet(b => b.BlinkOffset = 0.25f);
+                mockIntenseLight.VerifySet(b => b.BlinkLength = 2);
+                mockCoolLight.VerifySet(b => b.Color = new Color(0, 0, 255));
+                mockCoolLight.VerifySet(b => b.Falloff = 1);
+                mockCoolLight.VerifySet(b => b.Enabled = true);
+                mockIntenseLight.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void BlocksAloneAndInGroups()
+        {
+            String script = @"
+:lightshow
+set the ""single light"" intensity to 10
+set the ""hangar lights"" blinkInterval to 0.5
+set the ""hangar lights"" blinkOffset to 0.25
+turn on the ""hangar lights""
+";
+
+            using (ScriptTest test = new ScriptTest(script))
+            {
+                // In this test, single light and other light are both in
+                // a group called "hangar lights"
+                // We want to ensure that we're manipulating both lights when we
+                // perform commands on the group, but that we can still interact
+                // with just one of the lights when we want to
+                var mockSingleLight = new Mock<IMyLightingBlock>();
+                var mockOtherLight = new Mock<IMyLightingBlock>();
+                test.MockBlocksOfType("single light", mockSingleLight);
+                test.MockBlocksOfType("other light", mockOtherLight);
+                test.MockBlocksInGroup("hangar lights", mockSingleLight, mockOtherLight);
+
+                test.RunUntilDone();
+
+                mockSingleLight.VerifySet(b => b.Intensity = 10f);
+                mockSingleLight.VerifySet(b => b.BlinkIntervalSeconds = 0.5f);
+                mockSingleLight.VerifySet(b => b.BlinkOffset = 0.25f);
+                mockOtherLight.VerifySet(b => b.BlinkIntervalSeconds = 0.5f);
+                mockOtherLight.VerifySet(b => b.BlinkOffset = 0.25f);
+                mockSingleLight.VerifySet(b => b.Enabled = true);
+                mockOtherLight.VerifySet(b => b.Enabled = true);
+                // We should have never manipulated the intensity of "other light"
+                mockOtherLight.VerifySet(b => b.Intensity = 10f, Times.Never);
             }
         }
     }

--- a/EasyCommands.Tests/ScriptTests/SimpleCommandExecutionTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleCommandExecutionTests.cs
@@ -21,7 +21,7 @@ print 'Hello World'
 ";
             using (var test = new ScriptTest(script))
             {
-                test.RunUntil(Program.ProgramState.COMPLETE);
+                test.RunUntilDone();
 
                 Assert.AreEqual(1, test.Logger.Count);
                 Assert.AreEqual("Hello World", test.Logger[0]);
@@ -39,7 +39,7 @@ print 'Hello World'
 
             using (var test = new ScriptTest(script))
             {
-                test.RunUntil(Program.ProgramState.COMPLETE);
+                test.RunUntilDone();
 
                 Assert.AreEqual(1, test.Logger.Count);
                 Assert.AreEqual("Hello World", test.Logger[0]);

--- a/EasyCommands.Tests/ScriptTests/SimpleCommandExecutionTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleCommandExecutionTests.cs
@@ -8,60 +8,43 @@ using Sandbox.ModAPI.Ingame;
 using SpaceEngineers.Game.ModAPI;
 using VRageMath;
 
-namespace EasyCommands.Tests {
+namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
     public class SimpleCommandExecutionTests {
 
 
         [TestMethod]
         public void printCommandTest() {
-            List<String> logger = new List<String>();
-            var me = new Mock<IMyProgrammableBlock>();
-
-            MDKFactory.ProgramConfig config = default;
-            config.Echo = (message) => logger.Add(message);
-            config.ProgrammableBlock = me.Object;
-
-            var program = MDKFactory.CreateProgram<Program>(config);
             String script = @"
 :main
 print 'Hello World'
 ";
-            me.Setup(b => b.CustomData).Returns(script);
-            Program.LOG_LEVEL = Program.LogLevel.SCRIPT_ONLY;
-            //TODO: Replace this with mock objects passed to config setup in Program.
-            Program.BROADCAST_MESSAGE_PROVIDER = (x) => new List<MyIGCMessage>();
+            using (var test = new ScriptTest(script))
+            {
+                test.RunUntil(Program.ProgramState.COMPLETE);
 
-            MDKFactory.Run(program);
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Hello World", test.Logger[0]);
+            }
 
-            Assert.AreEqual(1, logger.Count);
-            Assert.AreEqual("Hello World", logger[0]);
         }
 
         [TestMethod]
         public void commentsAreIgnored() {
-            List<String> logger = new List<String>();
-            var me = new Mock<IMyProgrammableBlock>();
-
-            MDKFactory.ProgramConfig config = default;
-            config.Echo = (message) => logger.Add(message);
-            config.ProgrammableBlock = me.Object;
-
-            var program = MDKFactory.CreateProgram<Program>(config);
             String script = @"
 :main
 #This is a comment
 print 'Hello World'
 ";
-            me.Setup(b => b.CustomData).Returns(script);
-            Program.LOG_LEVEL = Program.LogLevel.SCRIPT_ONLY;
-            //TODO: Replace this with mock objects passed to config setup in Program.
-            Program.BROADCAST_MESSAGE_PROVIDER = (x) => new List<MyIGCMessage>();
 
-            MDKFactory.Run(program);
+            using (var test = new ScriptTest(script))
+            {
+                test.RunUntil(Program.ProgramState.COMPLETE);
 
-            Assert.AreEqual(1, logger.Count);
-            Assert.AreEqual("Hello World", logger[0]);
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Hello World", test.Logger[0]);
+            }
+
         }
     }
 }

--- a/EasyCommands.Tests/Util/Extensions.cs
+++ b/EasyCommands.Tests/Util/Extensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EasyCommands.Tests.Util
+{
+    public static class Extensions
+    {
+        public static HashSet<T> ToHashSet<T>(this IEnumerable<T> source, IEqualityComparer<T> comparer = null)
+        {
+            return new HashSet<T>(source, comparer);
+        }
+    }
+}

--- a/EasyCommands/BlockHandlers/BlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/BlockHandlers.cs
@@ -10,9 +10,6 @@ using VRageMath;
 namespace IngameScript {
     partial class Program {
         public static class BlockHandlerRegistry {
-            public delegate List<Object> BlockProvider(BlockType blockType, String name);
-            public static BlockProvider BLOCK_PROVIDER = GetBlocks;
-            public static BlockProvider GROUP_BLOCK_PROVIDER = GetBlocksInGroup;
 
             static readonly Dictionary<BlockType, BlockHandler> blockHandlers = new Dictionary<BlockType, BlockHandler> {
                { BlockType.AIRVENT, new AirVentBlockHandler()},

--- a/EasyCommands/Commands/EntityProviders.cs
+++ b/EasyCommands/Commands/EntityProviders.cs
@@ -80,7 +80,7 @@ namespace IngameScript {
 
             public List<Object> GetEntities() {
                 String selectorString = CastString(selector.GetValue()).GetStringValue();
-                List<object> entities = isGroup ? BlockHandlerRegistry.GROUP_BLOCK_PROVIDER(blockType, selectorString) : BlockHandlerRegistry.BLOCK_PROVIDER(blockType, selectorString);
+                List<object> entities = isGroup ? BlockHandlerRegistry.GetBlocksInGroup(blockType, selectorString) : BlockHandlerRegistry.GetBlocks(blockType, selectorString);
                 return entities;
             }
 
@@ -105,7 +105,7 @@ namespace IngameScript {
             }
 
             public List<object> GetEntities() {
-                return BlockHandlerRegistry.GROUP_BLOCK_PROVIDER(blockType, PROGRAM.Me.CustomName);
+                return BlockHandlerRegistry.GetBlocksInGroup(blockType, PROGRAM.Me.CustomName);
             }
         }
     }

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -36,16 +36,16 @@ namespace IngameScript {
         static String ARGUMENT;
         static List<String> COMMAND_STRINGS = new List<String>();
         static MyGridProgram PROGRAM;
-        static ProgramState STATE = ProgramState.STOPPED;
+        public static ProgramState STATE = ProgramState.STOPPED;
         public delegate String CustomDataProvider(MyGridProgram program);
-        public delegate List<MyIGCMessage> BroadcastMessageProvider(MyGridProgram program);
-        public static BroadcastMessageProvider BROADCAST_MESSAGE_PROVIDER = provideMessages;
+        public delegate List<MyIGCMessage> BroadcastMessageProvider();
+        public BroadcastMessageProvider broadcastMessageProvider;
         static Dictionary<String, Variable> memoryVariables = new Dictionary<string, Variable>();
 
-        static List<MyIGCMessage> provideMessages(MyGridProgram program)
+        List<MyIGCMessage> provideMessages()
         {
             List<IMyBroadcastListener> listeners = new List<IMyBroadcastListener>();
-            program.IGC.GetBroadcastListeners(listeners);
+            IGC.GetBroadcastListeners(listeners);
             return listeners.Where(l => l.HasPendingMessage).Select(l => l.AcceptMessage()).ToList();
         }
 
@@ -55,6 +55,7 @@ namespace IngameScript {
             ParameterProcessorRegistry.InitializeProcessors();
             InitializeOperators();
             Runtime.UpdateFrequency = UPDATE_FREQUENCY;
+            broadcastMessageProvider = provideMessages;
         }
 
         static void Print(String str) { PROGRAM.Echo(str); }
@@ -81,7 +82,7 @@ namespace IngameScript {
             Debug("Functions: " + FUNCTIONS.Count);
             Debug("Argument: " + ARGUMENT);
 
-            List<MyIGCMessage> messages = BROADCAST_MESSAGE_PROVIDER(PROGRAM);
+            List<MyIGCMessage> messages = broadcastMessageProvider();
 
             try {
                 if (messages.Count > 0) {


### PR DESCRIPTION
Revamped ScriptTests by adding ScriptTest utility class
This greatly reduces the required boilerplate in writing script tests
by delegating most of that to the construction of a ScriptTest instance.

ScriptTest authors only need to provide the actual script,
the mocked objects, and the verifications/assertions for those mocks.

As part of this, I replaced block and group entity providers with
mocking of the GridTerminalSystem. However, I haven't yet configured
it to work properly for display blocks. I wanted to get this bit out
and reviewed before then proceeding to address the display block gap.

As a result, you'll see changes to EasyCommands for the removal of the
block provider delegates, as those are no longer required.

Other notable changes:
* Changed STATE in Program to be public so we can both examine it
  and set it from tests
* Changed the BroadcastMessageProvider delegate to not be static
  so that we don't have to potentially reset it after each test run