### PR TITLE
Refactored ParameterProcessors to use Rule Based Processing

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/SimpleCommandProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleCommandProcessorTests.cs
@@ -125,5 +125,79 @@ namespace EasyCommands.Tests {
             ComparisonVariable comparison = (ComparisonVariable)assignCommand.variable;
             Assert.IsTrue(comparison.a is InMemoryVariable);
         }
+
+        [TestMethod]
+        public void IterateSimpleCommand() {
+            var command = ParseCommand("print \"hello world\" 3 times");
+            Assert.IsTrue(command is MultiActionCommand);
+            MultiActionCommand iterateCommand = (MultiActionCommand)command;
+            Assert.AreEqual(3f, iterateCommand.loopCount.GetValue().GetValue());
+            List<Command> commands = iterateCommand.commandsToExecute;
+            Assert.AreEqual(1, commands.Count);
+            Assert.IsTrue(commands[0] is PrintCommand);
+            PrintCommand printCommand = (PrintCommand)commands[0];
+            Assert.AreEqual("hello world", printCommand.variable.GetValue().GetValue());
+        }
+
+        [TestMethod]
+        public void IterateSimpleCommandAfter() {
+            var command = ParseCommand("for 3 times print \"hello world\"");
+            Assert.IsTrue(command is MultiActionCommand);
+            MultiActionCommand iterateCommand = (MultiActionCommand)command;
+            Assert.AreEqual(3f, iterateCommand.loopCount.GetValue().GetValue());
+            List<Command> commands = iterateCommand.commandsToExecute;
+            Assert.AreEqual(1, commands.Count);
+            Assert.IsTrue(commands[0] is PrintCommand);
+            PrintCommand printCommand = (PrintCommand)commands[0];
+            Assert.AreEqual("hello world", printCommand.variable.GetValue().GetValue());
+        }
+
+        [TestMethod]
+        public void StopCommand() {
+            var command = ParseCommand("stop");
+            Assert.IsTrue(command is ControlCommand);
+            ControlCommand controlCommand = (ControlCommand)command;
+            Assert.AreEqual(ControlType.STOP, controlCommand.controlType);
+        }
+
+        [TestMethod]
+        public void StartCommand() {
+            var command = ParseCommand("start");
+            Assert.IsTrue(command is ControlCommand);
+            ControlCommand controlCommand = (ControlCommand)command;
+            Assert.AreEqual(ControlType.START, controlCommand.controlType);
+        }
+
+        [TestMethod]
+        public void RestartCommand() {
+            var command = ParseCommand("restart");
+            Assert.IsTrue(command is ControlCommand);
+            ControlCommand controlCommand = (ControlCommand)command;
+            Assert.AreEqual(ControlType.RESTART, controlCommand.controlType);
+        }
+
+        [TestMethod]
+        public void RepeatCommand() {
+            var command = ParseCommand("repeat");
+            Assert.IsTrue(command is ControlCommand);
+            ControlCommand controlCommand = (ControlCommand)command;
+            Assert.AreEqual(ControlType.REPEAT, controlCommand.controlType);
+        }
+
+        [TestMethod]
+        public void PauseCommand() {
+            var command = ParseCommand("pause");
+            Assert.IsTrue(command is ControlCommand);
+            ControlCommand controlCommand = (ControlCommand)command;
+            Assert.AreEqual(ControlType.PAUSE, controlCommand.controlType);
+        }
+
+        [TestMethod]
+        public void ResumeCommand() {
+            var command = ParseCommand("resume");
+            Assert.IsTrue(command is ControlCommand);
+            ControlCommand controlCommand = (ControlCommand)command;
+            Assert.AreEqual(ControlType.START, controlCommand.controlType);
+        }
     }
 }

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -279,6 +279,7 @@ namespace IngameScript {
         static Dictionary<String, ControlType> controlTypeWords = new Dictionary<string, ControlType>()
         {
             { "start", ControlType.START },
+            { "resume", ControlType.START },
             { "restart", ControlType.RESTART },
             { "reset", ControlType.RESTART },
             { "reboot", ControlType.RESTART },
@@ -287,7 +288,6 @@ namespace IngameScript {
             { "replay", ControlType.REPEAT },
             { "stop", ControlType.STOP },
             { "pause", ControlType.PAUSE },
-            { "resume", ControlType.RESUME },
         };
 
         static Dictionary<String, Color> colors = new Dictionary<String, Color>{

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -24,59 +24,262 @@ namespace IngameScript {
 
             private static List<ParameterProcessor> parameterProcessors = new List<ParameterProcessor>
             {
-                  new ParenthesisProcessor(),
-                  new FunctionProcessor(),
-                  new AssignmentProcessor(),
-                  new RunArgumentProcessor(),
-                  new SelfSelectorProcessor(),
-                  new SelectorProcessor(),
-                  new VariableSelectorProcessor(),
-                  new PrimitiveProcessor(),
-                  new RedundantComparisonProcessor(),
-                  new UniOperationProcessor(),
-                  new MultiplyProcessor(),
-                  new AddProcessor(),
-                  new AndProcessor(),
-                  new OrProcessor(),
-                  new NotProcessor(),
-                  new VariableComparisonProcessor(),
-                  new BlockComparisonProcessor(),
-                  new IndexProcessor(),
-                  new ConditionalSelectorProcessor(),
-                  new IndexSelectorProcessor(),
-                  new PropertyAggregationProcessor(),
-                  new AggregationProcessor(),
-                  new IteratorProcessor(),
-                  new IfProcessor(),
-                  new IterationProcessor(),
-                  new ActionProcessor(),
-                  new PrintCommandProcessor(),
-                  new WaitProcessor(),
-                  new FunctionCallCommandProcessor(),
-                  new VariableAssignmentProcesor(),
-                  new SendCommandProcessor(),
-                  new ListenCommandProcessor(),
-                  new ControlProcessor(),
-                  new IterationProcessor(),
-                  new ConditionalCommandProcessor(),
-                  new QueueCommandProcessor()
+                new ParenthesisProcessor(),
+
+                //FunctionProcessor
+                OneValueRule<FunctionCommandParameter,StringCommandParameter>(
+                    requiredRight<StringCommandParameter>(),
+                    (p,name) => {
+                        FunctionDefinition definition;
+                        if(!FUNCTIONS.TryGetValue(name.GetValue().Value, out definition)) throw new Exception("Unknown function: " + name.GetValue().Value);
+                        return new FunctionDefinitionCommandParameter(p.Value, definition);
+                    }),
+
+                //AssignmentProcessor
+                OneValueRule<AssignmentCommandParameter,StringCommandParameter>(
+                    requiredRight<StringCommandParameter>(),
+                    (p,name) => new VariableAssignmentCommandParameter(name.GetValue().Value, p.useReference)),
+
+                //SelfSelectorProcessor
+                OneValueRule<SelfCommandParameter,BlockTypeCommandParameter>(
+                    optionalRight<BlockTypeCommandParameter>(),
+                    (p, blockType) => new SelectorCommandParameter(new SelfEntityProvider(blockType.HasValue() ? blockType.GetValue().Value : BlockType.PROGRAM))),
+
+                //SelectorProcessor
+                TwoValueRule<StringCommandParameter,BlockTypeCommandParameter,GroupCommandParameter>(
+                      optionalRight<BlockTypeCommandParameter>(),optionalRight<GroupCommandParameter>(),
+                      (p,blockType,group) => {
+                        if (!blockType.HasValue()) {
+                            BlockTypeCommandParameter type = findLast<BlockTypeCommandParameter>(p.SubTokens);
+                            if (type != null) blockType.SetValue(type);
+                            GroupCommandParameter g = findFirst<GroupCommandParameter>(p.SubTokens);
+                            if (g != null) group.SetValue(g);
+                        }
+                        return blockType.HasValue();
+                      },
+                      (p,blockType,group) => new SelectorCommandParameter(new SelectorEntityProvider(blockType.GetValue().Value, group.HasValue(), new StaticVariable(new StringPrimitive(p.Value))))),
+
+                //VariableSelectorProcessor
+                TwoValueRule<VariableSelectorCommandParameter,BlockTypeCommandParameter,GroupCommandParameter>(
+                    requiredRight<BlockTypeCommandParameter>(),optionalRight<GroupCommandParameter>(),
+                    (p,blockType,group) => new SelectorCommandParameter(new SelectorEntityProvider(blockType.GetValue().Value, group.HasValue(), p.Value))),
+
+                //Primitive Procesor
+                new PrimitiveProcessor(),
+
+                //RedundantComparisonProcessor
+                //"is not <" => "!<"
+                //"is <" => "<"
+                //"is not" => !=
+                // "not greater than" => <
+                OneValueRule<ComparisonCommandParameter,NotCommandParameter>(
+                    requiredEither<NotCommandParameter>(),
+                    (p,left) => new ComparisonCommandParameter(Inverse(p.Value))),
+                OneValueRule<ComparisonCommandParameter,ComparisonCommandParameter>(
+                    requiredRight<ComparisonCommandParameter>(),
+                    (p,right) => new ComparisonCommandParameter(right.GetValue().Value)),
+
+                //UniOperationProcessor
+                OneValueRule<UniOperationCommandParameter,VariableCommandParameter>(
+                    requiredRight<VariableCommandParameter>(),
+                    (p,df) => new VariableCommandParameter(new UniOperandVariable(p.Value, df.GetValue().Value))),
+
+                //MultiplyProcessor
+                TwoValueRule<MultiplyCommandParameter,VariableCommandParameter,VariableCommandParameter>(
+                    requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
+                    (p,a,b) => new VariableCommandParameter(new BiOperandVariable(p.Value, a.GetValue().Value, b.GetValue().Value))),
+
+                //AddProcessor
+                TwoValueRule<AddCommandParameter,VariableCommandParameter,VariableCommandParameter>(
+                    requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
+                    (p,a,b) => new VariableCommandParameter(new BiOperandVariable(p.Value, a.GetValue().Value, b.GetValue().Value))),
+
+                //AndProcessor
+                TwoValueRule<AndCommandParameter,VariableCommandParameter,VariableCommandParameter>(
+                    requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
+                    (p,left,right) => new VariableCommandParameter(new BiOperandVariable(BiOperandType.AND, left.GetValue().Value, right.GetValue().Value))),
+                TwoValueRule<AndCommandParameter,BlockConditionCommandParameter,BlockConditionCommandParameter>(
+                    requiredLeft<BlockConditionCommandParameter>(), requiredRight<BlockConditionCommandParameter>(),
+                    (p,left,right) => new BlockConditionCommandParameter(new AndBlockCondition(left.GetValue().Value, right.GetValue().Value))),
+
+                //OrProcessor
+                TwoValueRule<OrCommandParameter,VariableCommandParameter,VariableCommandParameter>(
+                    requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
+                    (p,left,right) => new VariableCommandParameter(new BiOperandVariable(BiOperandType.OR, left.GetValue().Value, right.GetValue().Value))),
+                TwoValueRule<OrCommandParameter,BlockConditionCommandParameter,BlockConditionCommandParameter>(
+                    requiredLeft<BlockConditionCommandParameter>(), requiredRight<BlockConditionCommandParameter>(),
+                    (p,left,right) => new BlockConditionCommandParameter(new OrBlockCondition(left.GetValue().Value, right.GetValue().Value))),
+
+                //NotProcessor
+                OneValueRule<NotCommandParameter,VariableCommandParameter>(
+                    requiredRight<VariableCommandParameter>(),
+                    (p,right) => new VariableCommandParameter(new UniOperandVariable(UniOperandType.NOT, right.GetValue().Value))),
+
+                //VariableComparisonProcessor
+                TwoValueRule<ComparisonCommandParameter,VariableCommandParameter,VariableCommandParameter>(
+                    requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
+                    (p,left,right) => new VariableCommandParameter(new ComparisonVariable(left.GetValue().Value, right.GetValue().Value, new PrimitiveComparator(p.Value)))),
+
+                //BlockComparisonProcessor
+                ThreeValueRule<ComparisonCommandParameter,PropertyCommandParameter,DirectionCommandParameter,VariableCommandParameter>(
+                    optionalEither<PropertyCommandParameter>(),optionalEither<DirectionCommandParameter>(),optionalRight<VariableCommandParameter>(),
+                    (p,prop,dir,var) => var.HasValue() || prop.HasValue(),
+                    (p,prop,dir,var) => {
+                        Variable variable = var.HasValue() ? var.GetValue().Value : new StaticVariable(new BooleanPrimitive(true));
+                        PropertyType? property = null;
+                        if(prop.HasValue()) property = prop.GetValue().Value;
+                        DirectionType? direction = null;
+                        if(dir.HasValue()) direction = dir.GetValue().Value;
+                        return new BlockConditionCommandParameter(new BlockPropertyCondition(property, direction, new PrimitiveComparator(p.Value), variable));
+                    }),
+
+                //IndexProcessor
+                OneValueRule<IndexCommandParameter,VariableCommandParameter>(
+                    requiredRight<VariableCommandParameter>(),
+                    (p,var) => new IndexSelectorCommandParameter(var.GetValue().Value)),
+
+                //ConditionalSelectorProcessor
+                TwoValueRule<WithCommandParameter,SelectorCommandParameter, BlockConditionCommandParameter>(
+                    requiredLeft<SelectorCommandParameter>(),requiredRight<BlockConditionCommandParameter>(),
+                    (p,selector,condition) => new SelectorCommandParameter(new ConditionalEntityProvider(selector.GetValue().Value, condition.GetValue().Value))),
+
+                //IndexSelectorProcessor
+                OneValueRule<IndexSelectorCommandParameter,SelectorCommandParameter>(
+                    requiredLeft<SelectorCommandParameter>(),
+                    (p,selector) => new SelectorCommandParameter(new IndexEntityProvider(selector.GetValue().Value,p.Value))),
+
+                //PropertyAggregationProcessor
+                ThreeValueRule<PropertyAggregationCommandParameter,SelectorCommandParameter,PropertyCommandParameter,DirectionCommandParameter>(
+                    requiredEither<SelectorCommandParameter>(),optionalEither<PropertyCommandParameter>(),optionalEither<DirectionCommandParameter>(),
+                    (p,selector,property,direction) => selector.HasValue(),
+                    (p,selector,prop,dir) => {
+                        PropertyType? property = null;
+                        if(prop.HasValue()) property = prop.GetValue().Value;
+                        DirectionType? direction = null;
+                        if(dir.HasValue()) direction = dir.GetValue().Value;
+                        return new VariableCommandParameter(new AggregatePropertyVariable(p.Value, selector.GetValue().Value, property, direction));
+                    }),
+
+                //AggregationProcessor
+                TwoValueRule<BlockConditionCommandParameter,AggregationModeCommandParameter,SelectorCommandParameter>(
+                    optionalLeft<AggregationModeCommandParameter>(),requiredLeft<SelectorCommandParameter>(),
+                    (p,aggregation,selector) => {
+                        AggregationMode mode = aggregation.HasValue() ? aggregation.GetValue().Value : AggregationMode.ALL;
+                        return new VariableCommandParameter(new AggregateConditionVariable(mode, p.Value, selector.GetValue().Value));
+                    }),
+
+                //IteratorProcessor
+                OneValueRule<IteratorCommandParameter,VariableCommandParameter>(
+                    requiredLeft<VariableCommandParameter>(),
+                    (p,var) => new IterationCommandParameter(var.GetValue().Value)),
+
+                //IfProcessor
+                OneValueRule<IfCommandParameter,VariableCommandParameter>(
+                    requiredRight<VariableCommandParameter>(),
+                    (p,var) => new ConditionCommandParameter(p.inverseCondition ? new UniOperandVariable(UniOperandType.NOT, var.GetValue().Value) : var.GetValue().Value, p.alwaysEvaluate, p.swapCommands)),
+
+                //ActionProcessor
+                //TODO I'll be back for you
+                //new ActionProcessor(),
+                BlockCommandProcessor(),
+
+                //PrintCommandProcessor
+                OneValueRule<PrintCommandParameter,VariableCommandParameter>(
+                    requiredRight<VariableCommandParameter>(),
+                    (p,var) => new CommandReferenceParameter(new PrintCommand(var.GetValue().Value))),
+
+                //WaitProcessor
+                TwoValueRule<WaitCommandParameter,VariableCommandParameter,UnitCommandParameter>(
+                    optionalRight<VariableCommandParameter>(),optionalRight<UnitCommandParameter>(),
+                    (p,time,unit) => {
+                        UnitType units = unit.HasValue() ? unit.GetValue().Value : time.HasValue() ? UnitType.SECONDS : UnitType.TICKS;
+                        Variable var = time.HasValue() ? time.GetValue().Value : new StaticVariable(new NumberPrimitive(1));
+                        return new CommandReferenceParameter(new WaitCommand(var, units));
+                    }),
+
+                //FunctionCallCommandProcessor
+                OneValueRule<FunctionDefinitionCommandParameter,VariableCommandParameter>(
+                    rightList<VariableCommandParameter>(true),
+                    (p,variables) => ((ListValueDataFetcher<VariableCommandParameter>)variables).GetValues().Count == p.functionDefinition.parameterNames.Count,
+                    (p,variables) => {
+                        List<VariableCommandParameter> parameters = ((ListValueDataFetcher<VariableCommandParameter>)variables).GetValues();
+                        Dictionary<string, Variable> inputParameters = new Dictionary<string, Variable>();
+                        for (int i = 0; i < p.functionDefinition.parameterNames.Count; i++) {
+                            inputParameters[p.functionDefinition.parameterNames[i]] = parameters[i].Value;
+                        }
+                        Command command = new FunctionCommand(p.functionType, p.functionDefinition, inputParameters);
+                        return new CommandReferenceParameter(command);
+                    }),
+
+                //VariableAssignmentProcessor
+                OneValueRule<VariableAssignmentCommandParameter,VariableCommandParameter>(
+                    requiredRight<VariableCommandParameter>(),
+                    (p,var) => new CommandReferenceParameter(new VariableAssignmentCommand(p.variableName, var.GetValue().Value, p.useReference))),
+
+                //SendCommandProcessor
+                //Note: Message to send always comes first: "send <command> to <tag>" is only supported format
+                TwoValueRule<SendCommandParameter,VariableCommandParameter,VariableCommandParameter>(
+                    requiredRight<VariableCommandParameter>(),requiredRight<VariableCommandParameter>(),
+                    (p,message,tag) => new CommandReferenceParameter(new SendCommand(message.GetValue().Value, tag.GetValue().Value))),
+
+                //ListenCommandProcessor
+                OneValueRule<ListenCommandParameter,VariableCommandParameter>(
+                    requiredRight<VariableCommandParameter>(),
+                    (p,var) => new CommandReferenceParameter(new ListenCommand(var.GetValue().Value))),
+
+                //ControlProcessor 
+                NoValueRule<ControlCommandParameter>((p) => new CommandReferenceParameter(new ControlCommand(p.Value))),
+
+                //IterationProcessor
+                OneValueRule<IterationCommandParameter,CommandReferenceParameter>(
+                    requiredEither<CommandReferenceParameter>(),
+                    (p,command) => new CommandReferenceParameter(new MultiActionCommand(new List<Command> {command.GetValue().Value}, p.Value))),
+
+                //QueueProcessor
+                OneValueRule<QueueCommandParameter,CommandReferenceParameter>(
+                    requiredRight<CommandReferenceParameter>(),
+                    (p,command) => new CommandReferenceParameter(new QueueCommand(command.GetValue().Value,p.Value))),
+
+                //ConditionalCommandProcessor
+                //condition command
+                //condition command otherwise command
+                ThreeValueRule<ConditionCommandParameter,CommandReferenceParameter,ElseCommandParameter,CommandReferenceParameter>(
+                    requiredRight<CommandReferenceParameter>(),optionalRight<ElseCommandParameter>(),optionalRight<CommandReferenceParameter>(),
+                    ConvertConditionalCommand),
+                //command condition
+                //command condition otherwise command
+                ThreeValueRule<ConditionCommandParameter,CommandReferenceParameter,ElseCommandParameter,CommandReferenceParameter>(
+                    requiredLeft<CommandReferenceParameter>(),optionalRight<ElseCommandParameter>(),optionalRight<CommandReferenceParameter>(),
+                    ConvertConditionalCommand),
             };
 
+            static CommandParameter ConvertConditionalCommand(ConditionCommandParameter condition, DataFetcher<CommandReferenceParameter> metFetcher,
+                DataFetcher<ElseCommandParameter> otherwise, DataFetcher<CommandReferenceParameter> notMetFetcher) {
+                Command metCommand = metFetcher.GetValue().Value;
+                Command notMetCommand = otherwise.HasValue() ? notMetFetcher.GetValue().Value : new NullCommand();
+                if (condition.swapCommands) {
+                    var temp = metCommand;
+                    metCommand = notMetCommand;
+                    notMetCommand = temp;
+                }
+                Command command = new ConditionalCommand(condition.Value, metCommand, notMetCommand, condition.alwaysEvaluate);
+                return new CommandReferenceParameter(command);
+            }
+
             static Dictionary<Type, List<ParameterProcessor>> parameterProcessorsByParameterType = new Dictionary<Type, List<ParameterProcessor>>();
-            static Dictionary<Type, int> priorityByParameterProcessor = new Dictionary<Type, int>();
 
             public static void InitializeProcessors() {
                 if (initialized) return;
 
-                for(int i = 0; i < parameterProcessors.Count; i++) {
+                for (int i = 0; i < parameterProcessors.Count; i++) {
                     ParameterProcessor processor = parameterProcessors[i];
+                    processor.SetRank(i);
 
                     List<Type> types = processor.GetProcessedTypes();
                     foreach (Type t in types) {
                         if (!parameterProcessorsByParameterType.ContainsKey(t)) parameterProcessorsByParameterType[t] = new List<ParameterProcessor>();
                         parameterProcessorsByParameterType[t].Add(processor);
                     }
-                    priorityByParameterProcessor[processor.GetType()] = i;
                     initialized = true;
                 }
             }
@@ -90,12 +293,12 @@ namespace IngameScript {
 
                 int processorIndex = 0;
 
-                while(processorIndex < sortedParameterProcessors.Count) {
+                while (processorIndex < sortedParameterProcessors.Count) {
                     bool revisit = false;
                     bool processed = false;
                     ParameterProcessor current = sortedParameterProcessors[processorIndex];
-                    for(int i = 0;i<commandParameters.Count;i++) {
-                        if(current.CanProcess(commandParameters[i])) {
+                    for (int i = 0; i < commandParameters.Count; i++) {
+                        if (current.CanProcess(commandParameters[i])) {
                             List<CommandParameter> finalParameters;
                             if (current.Process(commandParameters, i, out finalParameters)) {
                                 AddProcessors(finalParameters, sortedParameterProcessors);
@@ -116,88 +319,162 @@ namespace IngameScript {
                     List<ParameterProcessor> processors;
                     if (!parameterProcessorsByParameterType.TryGetValue(types[i].GetType(), out processors)) continue;
                     foreach (ParameterProcessor processor in processors) {
-                        if(!sortedParameterProcessors.Contains(processor)) InsertProcessor(processor, sortedParameterProcessors);
-                     }
+                        if (!sortedParameterProcessors.Contains(processor)) InsertProcessor(processor, sortedParameterProcessors);
+                    }
                 }
             }
 
             static void InsertProcessor(ParameterProcessor processor, List<ParameterProcessor> parameterProcessors) {
-                int priority = priorityByParameterProcessor[processor.GetType()];
+                int priority = processor.GetRank();
                 int i = 0;
-                while (i < parameterProcessors.Count() && priorityByParameterProcessor[parameterProcessors[i].GetType()] < priority) i++;
+                while (i < parameterProcessors.Count() && parameterProcessors[i].GetRank() < priority) i++;
                 parameterProcessors.Insert(i, processor);
             }
         }
 
+        delegate bool CanConvert<T>(T t);
+        delegate bool OneValueCanConvert<T,U>(T t, DataFetcher<U> a);
+        delegate bool TwoValueCanConvert<T,U,V>(T t, DataFetcher<U> a, DataFetcher<V> b);
+        delegate bool ThreeValueCanConvert<T, U, V, W>(T t, DataFetcher<U> a, DataFetcher<V> b, DataFetcher<W> c);
+
+        delegate CommandParameter Convert<T>(T t);
+        delegate CommandParameter OneValueConvert<T, U>(T t, DataFetcher<U> a) where T : CommandParameter;
+        delegate CommandParameter TwoValueConvert<T, U, V>(T t, DataFetcher<U> a, DataFetcher<V> b) where T : CommandParameter;
+        delegate CommandParameter ThreeValueConvert<T, U, V, W>(T t, DataFetcher<U> a, DataFetcher<V> b, DataFetcher<W> c);
+
+        delegate bool Process(CommandParameter p);
+        delegate Process ProcessCommandParameter(DataFetcher dataFetcher);
+
+        //Data Fetchers
+        interface DataFetcher {
+            bool Satisfied();
+            bool SetValue(CommandParameter p);
+            void Clear();
+        }
+
+        interface DataFetcher<T> : DataFetcher {
+            bool HasValue();
+            T GetValue();
+        }
+
+        class ValueDataFetcher<T> : DataFetcher<T> where T : class, CommandParameter {
+            T value = null;
+            bool required;
+
+            public ValueDataFetcher(bool required) {
+                this.required = required;
+            }
+
+            public void Clear() => value = null;
+            public bool HasValue() => value != null;
+            public T GetValue() => value;
+            public bool Satisfied() => !required || value != null;
+            public bool SetValue(CommandParameter p) {
+                if(p is T && value == null) { value = (T)p; return true; } return false;
+            }
+        }
+
+        class ListValueDataFetcher<T> : DataFetcher<T> where T : class, CommandParameter {
+            List<T> values = new List<T>();
+            bool required;
+
+            public ListValueDataFetcher(bool required) {
+                this.required = required;
+            }
+
+            public void Clear() => values.Clear();
+
+            public T GetValue() => values[0];
+
+            public List<T> GetValues() => values;
+            public bool HasValue() => values.Count() > 0;
+            public bool Satisfied() => !required || HasValue();
+            public bool SetValue(CommandParameter p) {
+                if (p is T) { values.Add((T)p); return true; }
+                return false;
+            }
+        }
+
+        //DataProcessors
+        class DataProcessor {
+            public DataFetcher fetcher;
+            public Process left;
+            public Process right;
+            public DataProcessor(DataFetcher f, ProcessCommandParameter l, ProcessCommandParameter r) {
+                fetcher = f;
+                left = l(f);
+                right = r(f);
+            }
+        }
+
+        class DataProcessor<U> : DataProcessor {
+            public DataFetcher<U> f;
+
+            public DataProcessor(DataFetcher<U> f, ProcessCommandParameter l, ProcessCommandParameter r) : base(f,l,r) {
+                this.f = f;
+            }
+        }
+
+        static DataProcessor<T> requiredRight<T>() where T : class, CommandParameter {
+            return right<T>(true);
+        }
+
+        static DataProcessor<T> requiredLeft<T>() where T : class, CommandParameter {
+            return left<T>(true);
+        }
+
+        static DataProcessor<T> requiredEither<T>() where T : class, CommandParameter {
+            return either<T>(true);
+        }
+
+        static DataProcessor<T> optionalRight<T>() where T : class, CommandParameter {
+            return right<T>(false);
+        }
+
+        static DataProcessor<T> optionalLeft<T>() where T : class, CommandParameter {
+            return left<T>(false);
+        }
+
+        static DataProcessor<T> optionalEither<T>() where T : class, CommandParameter {
+            return either<T>(false);
+        }
+
+        static DataProcessor<T> right<T>(bool required) where T : class, CommandParameter {
+            return new DataProcessor<T>(new ValueDataFetcher<T>(required), df => p => false ,df => p => df.SetValue(p));
+        }
+
+        static DataProcessor<T> left<T>(bool required) where T : class, CommandParameter {
+            return new DataProcessor<T>(new ValueDataFetcher<T>(required), df => p => df.SetValue(p), df => p => false);
+        }
+
+        static DataProcessor<T> either<T>(bool required) where T : class, CommandParameter {
+            return new DataProcessor<T>(new ValueDataFetcher<T>(required), df => p => df.SetValue(p), df => p => df.SetValue(p));
+        }
+
+        static DataProcessor<T> rightList<T>(bool required) where T: class, CommandParameter {
+            return new DataProcessor<T>(new ListValueDataFetcher<T>(required), df => p => false, df => p => df.SetValue(p));
+        }
+
+        //ParameterProcessors
         public interface ParameterProcessor {
             List<Type> GetProcessedTypes();
-            bool CanProcess(CommandParameter p);
+            bool CanProcess(CommandParameter p); 
             bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters);
+            int GetRank();
+            void SetRank(int rank);
         }
 
         public abstract class ParameterProcessor<T> : ParameterProcessor where T : class, CommandParameter {
+            int rank;
             public virtual List<Type> GetProcessedTypes() { return new List<Type>() { typeof(T) }; }
+            public virtual int GetRank() => rank;
+            public virtual void SetRank(int r) => rank = r;
             public bool CanProcess(CommandParameter p) {
                 return p is T;
             }
             public abstract bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters);
-        }
 
-        public abstract class SimpleParameterProcessor<T> : ParameterProcessor<T> where T : class, CommandParameter {
-            public abstract void Initialize();
-            public abstract bool ProcessLeft(CommandParameter p);
-            public abstract bool ProcessRight(CommandParameter p);
-            public abstract bool CanConvert(List<CommandParameter> p);
-            public abstract CommandParameter Convert(List<CommandParameter> p);
 
-            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters) {
-                finalParameters = null;
-                Initialize();
-                int j = i + 1;
-                while (j < p.Count) {
-                    if (ProcessRight(p[j])) j++;
-                    else break;
-                }
-
-                int k = i;
-                while (k > 0) {
-                    if (ProcessLeft(p[k - 1])) k--;
-                    else break;
-                }
-
-                List<CommandParameter> commandParameters = p.GetRange(k, j - k);
-
-                if (!CanConvert(commandParameters)) return false;
-
-                CommandParameter param = Convert(commandParameters);
-                p.RemoveRange(k, j - k);
-                p.Insert(k, param);
-                finalParameters = new List<CommandParameter>() { p[k] };
-                return true;
-            }
-        }
-
-        public abstract class SimpleCommandProcessor<T> : ParameterProcessor<T> where T : class, CommandParameter {
-            public abstract void Initialize();
-            public abstract bool CanConvert();
-            public abstract bool ProcessParameterArgument(CommandParameter p);
-            public abstract Command GetCommand(List<CommandParameter> commandParameters);
-            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters) {
-                finalParameters = null;
-                Initialize();
-                int j = i + 1;
-                while (j < p.Count) {
-                    if (ProcessParameterArgument(p[j])) j++;
-                    else break;
-                }
-
-                List<CommandParameter> commandParameters = p.GetRange(i, j - i);
-                Command command = GetCommand(commandParameters);
-                p.RemoveRange(i, j - i);
-                p.Insert(i, new CommandReferenceParameter(command));
-                finalParameters = new List<CommandParameter>() { p[i] };
-                return true;
-            }
         }
 
         public class ParenthesisProcessor : ParameterProcessor<OpenParenthesisCommandParameter> {
@@ -244,1018 +521,105 @@ namespace IngameScript {
             }
         }
 
-        public class MultiplyProcessor : SimpleParameterProcessor<MultiplyCommandParameter> {
-            Variable a, b;
-            public override bool CanConvert(List<CommandParameter> p) {
-                return a != null & b != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                BiOperandType operand = findFirst<MultiplyCommandParameter>(p).Value;
-                return new VariableCommandParameter(new BiOperandVariable(operand, a, b));
-            }
-
-            public override void Initialize() {
-                a = null;
-                b = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (p is VariableCommandParameter && a == null) {
-                    a = ((VariableCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is VariableCommandParameter && b == null) {
-                    b = ((VariableCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-        }
-
-        public class AddProcessor : SimpleParameterProcessor<AddCommandParameter> {
-            Variable a, b;
-            public override bool CanConvert(List<CommandParameter> p) {
-                return a != null & b != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                BiOperandType operand = findFirst<AddCommandParameter>(p).Value;
-                return new VariableCommandParameter(new BiOperandVariable(operand, a, b));
-            }
-
-            public override void Initialize() {
-                a = null;
-                b = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (p is VariableCommandParameter && a == null) {
-                    a = ((VariableCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is VariableCommandParameter && b == null) {
-                    b = ((VariableCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-        }
-
-        public class UniOperationProcessor : SimpleParameterProcessor<UniOperationCommandParameter> {
-            Variable variable;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return variable != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                UniOperandType operandType = findFirst<UniOperationCommandParameter>(p).Value;
-                return new VariableCommandParameter(new UniOperandVariable(operandType, variable));
-            }
-
-            public override void Initialize() {
-                variable = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is VariableCommandParameter && variable == null) variable = ((VariableCommandParameter)p).Value;
-                else return false;
-                return true;
-            }
-        }
-
-        public class AndProcessor : SimpleParameterProcessor<AndCommandParameter> {
-            CommandParameter left, right;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                if (left == null || right == null) return false;
-                if (left.GetType() != right.GetType()) return false;
-                return (left is BlockConditionCommandParameter ||
-                    left is VariableCommandParameter);
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                if (left is BlockConditionCommandParameter) {
-                    BlockCondition a = ((BlockConditionCommandParameter)left).Value;
-                    BlockCondition b = ((BlockConditionCommandParameter)right).Value;
-                    return new BlockConditionCommandParameter(new AndBlockCondition(a, b));
-                } else {
-                    Variable a = ((VariableCommandParameter)left).Value;
-                    Variable b = ((VariableCommandParameter)right).Value;
-                    return new VariableCommandParameter(new BiOperandVariable(BiOperandType.AND, a, b));
-                }
-            }
-
-            public override void Initialize() {
-                left = null;
-                right = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (left != null) return false;
-                left = p;
-                return true;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (right != null) return false;
-                right = p;
-                return true;
-            }
-        }
-
-        public class OrProcessor : SimpleParameterProcessor<OrCommandParameter> {
-            CommandParameter left, right;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                if (left == null || right == null) return false;
-                if (left.GetType() != right.GetType()) return false;
-                return (left is BlockConditionCommandParameter ||
-                    left is VariableCommandParameter);
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                if (left is BlockConditionCommandParameter) {
-                    BlockCondition a = ((BlockConditionCommandParameter)left).Value;
-                    BlockCondition b = ((BlockConditionCommandParameter)right).Value;
-                    return new BlockConditionCommandParameter(new OrBlockCondition(a, b));
-                } else {
-                    Variable a = ((VariableCommandParameter)left).Value;
-                    Variable b = ((VariableCommandParameter)right).Value;
-                    return new VariableCommandParameter(new BiOperandVariable(BiOperandType.OR, a, b));
-                }
-            }
-
-            public override void Initialize() {
-                left = null;
-                right = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (left != null) return false;
-                left = p;
-                return true;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (right != null) return false;
-                right = p;
-                return true;
-            }
-        }
-
-        public class NotProcessor : SimpleParameterProcessor<NotCommandParameter> {
-            Variable variable;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return variable != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                return new VariableCommandParameter(new UniOperandVariable(UniOperandType.NOT, variable));
-            }
-
-            public override void Initialize() {
-                variable = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is VariableCommandParameter && variable == null) {
-                    variable = ((VariableCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-        }
-
-        public class ConditionalSelectorProcessor : SimpleParameterProcessor<WithCommandParameter> {
-            EntityProvider entityProvider;
-            BlockCondition blockCondition;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return entityProvider != null && blockCondition != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                ConditionalEntityProvider provider = new ConditionalEntityProvider(entityProvider, blockCondition);
-                return new SelectorCommandParameter(provider);
-            }
-
-            public override void Initialize() {
-                entityProvider = null;
-                blockCondition = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (p is SelectorCommandParameter && entityProvider == null) {
-                    entityProvider = ((SelectorCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is BlockConditionCommandParameter && blockCondition == null) {
-                    blockCondition = ((BlockConditionCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-        }
-
-        public class IndexProcessor : SimpleParameterProcessor<IndexCommandParameter> {
-            Variable indexSelector;
-            public override bool CanConvert(List<CommandParameter> p) {
-                return indexSelector != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                return new IndexSelectorCommandParameter(indexSelector);
-            }
-
-            public override void Initialize() {
-                indexSelector = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is VariableCommandParameter && indexSelector == null) {
-                    indexSelector = ((VariableCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-        }
-
-        public class IndexSelectorProcessor : SimpleParameterProcessor<IndexSelectorCommandParameter> {
-            EntityProvider entityProvider;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return entityProvider != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                Variable indexSpecifier = findFirst<IndexSelectorCommandParameter>(p).Value;
-                EntityProvider provider = new IndexEntityProvider(entityProvider, indexSpecifier);
-                return new SelectorCommandParameter(provider);
-            }
-
-            public override void Initialize() {
-                entityProvider = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (p is SelectorCommandParameter && entityProvider == null) {
-                    entityProvider = ((SelectorCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                return false;
-            }
-        }
-
-        public class PropertyAggregationProcessor : SimpleParameterProcessor<PropertyAggregationCommandParameter> {
-            EntityProvider entityProvider;
-            PropertyType? property;
-            DirectionType? direction;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return entityProvider != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                PropertyAggregatorType aggregator = findFirst<PropertyAggregationCommandParameter>(p).Value;
-                return new VariableCommandParameter(new AggregatePropertyVariable(aggregator, entityProvider, property, direction));
-            }
-
-            public override void Initialize() {
-                entityProvider = null;
-                property = null;
-                direction = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return Process(p);
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                return Process(p);
-            }
-
-            bool Process(CommandParameter p) {
-                if (p is SelectorCommandParameter && entityProvider == null) entityProvider = ((SelectorCommandParameter)p).Value;
-                else if (p is PropertyCommandParameter && !property.HasValue) property = ((PropertyCommandParameter)p).Value;
-                else if (p is DirectionCommandParameter && !direction.HasValue) direction = ((DirectionCommandParameter)p).Value;
-                else return false;
-                return true;
-            }
-        }
-
-        public class AggregationProcessor : SimpleParameterProcessor<BlockConditionCommandParameter> {
-            AggregationMode? aggegration;
-            EntityProvider entityProvider;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return entityProvider != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                BlockCondition blockCondition = findFirst<BlockConditionCommandParameter>(p).Value;
-                Variable variable = new AggregateConditionVariable(aggegration.GetValueOrDefault(AggregationMode.ALL), blockCondition, entityProvider);
-                return new VariableCommandParameter(variable);
-            }
-
-            public override void Initialize() {
-                entityProvider = null;
-                aggegration = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (p is SelectorCommandParameter && entityProvider == null) {
-                    entityProvider = ((SelectorCommandParameter)p).Value;
-                    return true;
-                } else if (p is AggregationModeCommandParameter && !aggegration.HasValue) {
-                    aggegration = ((AggregationModeCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                return false;
-            }
-        }
-
-        //"is not <" => "!<"
-        //"is <" => "<"
-        //"is not" => !=
-        // "not greater than" => <
-        public class RedundantComparisonProcessor : SimpleParameterProcessor<ComparisonCommandParameter> {
-            ComparisonType? comparison;
-            bool invertComparison;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                ComparisonType implicitType = extractFirst<ComparisonCommandParameter>(p).Value;
-                return implicitType==ComparisonType.EQUAL && (comparison.HasValue || invertComparison); 
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                ComparisonType comp = comparison.GetValueOrDefault(ComparisonType.EQUAL);
-                if (invertComparison) comp = Inverse(comp);
-                return new ComparisonCommandParameter(comp);
-            }
-
-            public override void Initialize() {
-                comparison = null;
-                invertComparison = false;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (p is NotCommandParameter && !invertComparison && comparison == null) {
-                    invertComparison = true;
-                    return true;
-                } else return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is NotCommandParameter && !invertComparison && comparison == null) {
-                    invertComparison = true;
-                    return true;
-                } else if (p is ComparisonCommandParameter && comparison == null) {
-                    comparison = ((ComparisonCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-        }
-
-        public class BlockComparisonProcessor : SimpleParameterProcessor<ComparisonCommandParameter> {
-            Variable comparisonValue;
-            PropertyType? property;
-            DirectionType? direction;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return comparisonValue != null || (property.HasValue);
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                ComparisonType comparison = findFirst<ComparisonCommandParameter>(p).Value;
-
-                PrimitiveComparator comparator = new PrimitiveComparator(comparison);
-
-                if (comparisonValue == null) {
-                    comparisonValue = new StaticVariable(new BooleanPrimitive(true));
-                }
-
-                BlockCondition blockCondition = new BlockPropertyCondition(property, direction, comparator, comparisonValue);
-
-                return new BlockConditionCommandParameter(blockCondition);
-            }
-
-            public override void Initialize() {
-                comparisonValue = null;
-                property = null;
-                direction = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (p is PropertyCommandParameter && property == null) {
-                    property = ((PropertyCommandParameter)p).Value;
-                } else if (p is DirectionCommandParameter && direction == null) {
-                    direction = ((DirectionCommandParameter)p).Value;
-                } else return false;
-                return true;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is PropertyCommandParameter && property == null) {
-                    property = ((PropertyCommandParameter)p).Value;
-                } else if (p is DirectionCommandParameter && direction == null) {
-                    direction = ((DirectionCommandParameter)p).Value;
-                } else if (p is VariableCommandParameter && comparisonValue == null) {
-                    comparisonValue = ((VariableCommandParameter)p).Value;
-                } else return false;
-                return true;
-            }
-        }
-
-        public class VariableComparisonProcessor : SimpleParameterProcessor<ComparisonCommandParameter> {
-            Variable a, b;
-            public override bool CanConvert(List<CommandParameter> p) {
-                return a != null & b != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                ComparisonType comparison = extractFirst<ComparisonCommandParameter>(p).Value;
-                Variable v = new ComparisonVariable(a, b, new PrimitiveComparator(comparison));
-                return new VariableCommandParameter(v);
-            }
-
-            public override void Initialize() {
-                a = null;
-                b = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (p is VariableCommandParameter && a == null) {
-                    a = ((VariableCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is VariableCommandParameter && b == null) {
-                    b = ((VariableCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-        }
-
-        public class SelfSelectorProcessor : SimpleParameterProcessor<SelfCommandParameter> {
-            BlockType? blockType = null;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return true;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                return new SelectorCommandParameter(new SelfEntityProvider(blockType.GetValueOrDefault(BlockType.PROGRAM)));
-            }
-
-            public override void Initialize() {
-                blockType = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is BlockTypeCommandParameter && !blockType.HasValue) blockType = ((BlockTypeCommandParameter)p).Value;
-                else return false;
-                return true;
-            }
-        }
-
-        public class SelectorProcessor : SimpleParameterProcessor<StringCommandParameter> {
-            BlockType? blockType = null;
-            bool isGroup = false;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                StringCommandParameter selector = findFirst<StringCommandParameter>(p);
-                if (blockType == null) {
-                    BlockTypeCommandParameter type = findLast<BlockTypeCommandParameter>(selector.SubTokens);
-                    if (type != null) blockType = type.Value;
-                    if (selector.SubTokens.Exists(s => s is GroupCommandParameter)) isGroup = true;
-                }
-                return blockType != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                StringCommandParameter selector = findFirst<StringCommandParameter>(p);
-                Variable variable = new StaticVariable(new StringPrimitive(selector.Value));
-                return new SelectorCommandParameter(new SelectorEntityProvider(blockType.Value, isGroup, variable));
-            }
-
-            public override void Initialize() {
-                blockType = null;
-                isGroup = false;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is BlockTypeCommandParameter && blockType == null) blockType = ((BlockTypeCommandParameter)p).Value;
-                else if (p is GroupCommandParameter && !isGroup) isGroup = true;
-                else return false;
-                return true;
-            }
-        }
-
-        public class VariableSelectorProcessor : SimpleParameterProcessor<VariableSelectorCommandParameter> {
-            BlockType? blockType = null;
-            bool isGroup = false;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return blockType != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                VariableSelectorCommandParameter selector = findFirst<VariableSelectorCommandParameter>(p);
-                Variable variable = selector.Value;
-                return new SelectorCommandParameter(new SelectorEntityProvider(blockType.Value, isGroup, variable));
-            }
-
-            public override void Initialize() {
-                blockType = null;
-                isGroup = false;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is BlockTypeCommandParameter && blockType == null) blockType = ((BlockTypeCommandParameter)p).Value;
-                else if (p is GroupCommandParameter && !isGroup) isGroup = true;
-                else return false;
-                return true;
-            }
-        }
-
-        public class PrintCommandProcessor : SimpleParameterProcessor<PrintCommandParameter> {
-            Variable variable;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return variable != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                return new CommandReferenceParameter(new PrintCommand(variable));
-            }
-
-            public override void Initialize() {
-                variable = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
+        class RuleProcessor<T> : ParameterProcessor<T> where T : class, CommandParameter {
+            List<DataProcessor> processors;
+            CanConvert<T> canConvert;
+            Convert<T> convert;
 
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is VariableCommandParameter && variable == null) {
-                    variable = ((VariableCommandParameter)p).Value;
-                    return true;
-                } else return false;
+            public RuleProcessor(List<DataProcessor> processors, CanConvert<T> canConvert, Convert<T> convert) {
+                this.processors = processors;
+                this.canConvert = canConvert;
+                this.convert = convert;
             }
-        }
 
-        public class AssignmentProcessor : ParameterProcessor<AssignmentCommandParameter> {
             public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters) {
                 finalParameters = null;
-                if (i == p.Count - 1 || !(p[i + 1] is StringCommandParameter)) return false;
-                AssignmentCommandParameter assignment = (AssignmentCommandParameter)p[i];
-                StringCommandParameter variableName = (StringCommandParameter)p[i + 1];
-                p.RemoveRange(i, 2);
-                p.Insert(i, new VariableAssignmentCommandParameter(variableName.Value, assignment.useReference));
-                finalParameters = new List<CommandParameter>();
-                finalParameters.Add(p[i]);
+                processors.ForEach(dp => dp.fetcher.Clear());
+                int j = i + 1;
+                while (j < p.Count) {
+                    if (processors.Exists(dp => dp.right(p[j]))) j++;
+                    else break;
+                }
+
+                int k = i;
+                while (k > 0) {
+                    if (processors.Exists(dp => dp.left(p[k - 1]))) k--;
+                    else break;
+                }
+
+                List<CommandParameter> commandParameters = p.GetRange(k, j - k);
+
+
+                T hook = (T)p[i];
+                if (!canConvert(hook)) return false;
+                CommandParameter param = convert(hook);
+                p.RemoveRange(k, j - k);
+                p.Insert(k, param);
+                finalParameters = new List<CommandParameter>() { p[k] };
                 return true;
             }
         }
 
-        public class FunctionProcessor : ParameterProcessor<FunctionCommandParameter> {
-            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters) {
-                finalParameters = null;
-                if (i == p.Count - 1 || !(p[i + 1] is StringCommandParameter)) return false;
-                FunctionType functionType = ((FunctionCommandParameter)p[i]).Value;
-                StringCommandParameter functionName = (StringCommandParameter)p[i + 1];
-                FunctionDefinition definition;
-                if (!FUNCTIONS.TryGetValue(functionName.Value, out definition)) throw new Exception("Unknown function: " + functionName.Value);
-                p.RemoveRange(i, 2);
-                p.Insert(i, new FunctionDefinitionCommandParameter(functionType, definition));
-                finalParameters = new List<CommandParameter>();
-                finalParameters.Add(p[i]);
-                return true;
-            }
+        //Utility methods efficiently create Rule Processors
+        static RuleProcessor<T> NoValueRule<T>(Convert<T> convert) where T : class, CommandParameter {
+            return new RuleProcessor<T>(new List<DataProcessor>() { }, (p) => true, convert);
         }
 
-        public class RunArgumentProcessor : ParameterProcessor<StringCommandParameter> {
-            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters) {
-                finalParameters = null;
-                StringCommandParameter param = (StringCommandParameter)p[i];
-                if (param.SubTokens.Count == 0 || !(param.SubTokens[0] is PropertyCommandParameter)) return false;
-                if (((PropertyCommandParameter)param.SubTokens[0]).Value != PropertyType.RUN) return false;
-                Trace("Found Run Keyword!");
-                List<Token> values = ParseTokens(param.Value);
-                p.RemoveAt(i);
-                values.RemoveAt(0);
-                Trace("Arguments: (" + String.Join(" ", values) + ")");
-                p.Insert(i, new PropertyCommandParameter(PropertyType.RUN));
-                p.Insert(i + 1, new VariableCommandParameter(new StaticVariable(new StringPrimitive(String.Join(" ", values)))));
-                finalParameters = p.GetRange(i, 2);
-                return true;
-            }
+        static RuleProcessor<T> OneValueRule<T, U>(DataProcessor<U> u, OneValueConvert<T, U> convert) where T : class, CommandParameter {
+            return OneValueRule(u, (p, a) => a.Satisfied(), convert);
         }
 
-        public class WaitProcessor : SimpleCommandProcessor<WaitCommandParameter> {
-            bool unitIndex, timeIndex;
-
-            public override Command GetCommand(List<CommandParameter> commandParameters) {
-                return new WaitCommand(commandParameters);
-            }
-
-            public override void Initialize() {
-                unitIndex = false;
-                timeIndex = false;
-            }
-
-            public override bool CanConvert() {
-                return true;
-            }
-
-            public override bool ProcessParameterArgument(CommandParameter p) {
-                if (p is UnitCommandParameter && !unitIndex) unitIndex = true;
-                else if (p is VariableCommandParameter && !timeIndex) timeIndex = true;
-                else return false;
-                return true;
-            }
+        static RuleProcessor<T> OneValueRule<T, U>(DataProcessor<U> u, OneValueCanConvert<T, U> canConvert, OneValueConvert<T, U> convert) where T : class, CommandParameter {
+            return new RuleProcessor<T>(new List<DataProcessor>() { u }, (p) => canConvert(p, u.f), (p) => convert(p, u.f));
         }
 
-        public class ControlProcessor : SimpleParameterProcessor<ControlCommandParameter> {
-            public override bool CanConvert(List<CommandParameter> p) => true;
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                ControlType controlType = findFirst<ControlCommandParameter>(p).Value;
-                return new CommandReferenceParameter(new ControlCommand(controlType));
-            }
-
-            public override void Initialize() {}
-            public override bool ProcessLeft(CommandParameter p) => false;
-            public override bool ProcessRight(CommandParameter p) => false;
+        static RuleProcessor<T> TwoValueRule<T, U, V>(DataProcessor<U> u, DataProcessor<V> v, TwoValueConvert<T, U, V> convert) where T : class, CommandParameter {
+            return TwoValueRule(u, v, (p, a, b) => a.Satisfied() && b.Satisfied(), convert);
         }
 
-        public class SendCommandProcessor : SimpleCommandProcessor<SendCommandParameter> {
-            bool messageIndex, tagIndex;
-
-            public override Command GetCommand(List<CommandParameter> commandParameters) {
-                return new SendCommand(commandParameters);
-            }
-
-            public override void Initialize() {
-                tagIndex = false;
-                messageIndex = false;
-            }
-
-            public override bool CanConvert() {
-                return tagIndex && messageIndex;
-            }
-
-            public override bool ProcessParameterArgument(CommandParameter p) {
-                if (p is VariableCommandParameter && !messageIndex) messageIndex = true;
-                else if (p is VariableCommandParameter && !tagIndex) tagIndex = true;
-                else return false;
-                return true;
-            }
+        static RuleProcessor<T> TwoValueRule<T, U, V>(DataProcessor<U> u, DataProcessor<V> v, TwoValueCanConvert<T, U, V> canConvert, TwoValueConvert<T, U, V> convert) where T : class, CommandParameter {
+            return new RuleProcessor<T>(new List<DataProcessor>() { u, v }, (p) => canConvert(p, u.f, v.f), (p) => convert(p, u.f, v.f));
         }
 
-        public class ListenCommandProcessor : SimpleCommandProcessor<ListenCommandParameter> {
-            bool tagIndex;
-
-            public override Command GetCommand(List<CommandParameter> commandParameters) {
-                return new ListenCommand(commandParameters);
-            }
-
-            public override void Initialize() {
-                tagIndex = false;
-            }
-
-            public override bool CanConvert() {
-                return tagIndex;
-            }
-
-            public override bool ProcessParameterArgument(CommandParameter p) {
-                if (p is VariableCommandParameter && !tagIndex) tagIndex = true;
-                else return false;
-                return true;
-            }
+        static RuleProcessor<T> ThreeValueRule<T, U, V, W>(DataProcessor<U> u, DataProcessor<V> v, DataProcessor<W> w, ThreeValueConvert<T, U, V, W> convert) where T : class, CommandParameter {
+            return new RuleProcessor<T>(new List<DataProcessor>() { u, v, w }, (p) => u.f.Satisfied() && v.f.Satisfied() && v.f.Satisfied(), (p) => convert(p, u.f, v.f, w.f));
         }
 
-        public class VariableAssignmentProcesor : SimpleParameterProcessor<VariableAssignmentCommandParameter> {
-            Variable variable;
+        static RuleProcessor<T> ThreeValueRule<T, U, V, W>(DataProcessor<U> u, DataProcessor<V> v, DataProcessor<W> w, ThreeValueCanConvert<T, U, V, W> canConvert, ThreeValueConvert<T, U, V, W> convert) where T : class, CommandParameter {
+            return new RuleProcessor<T>(new List<DataProcessor>() { u, v, w }, (p) => canConvert(p, u.f, v.f, w.f), (p) => convert(p, u.f, v.f, w.f));
+        }
 
-            public override bool CanConvert(List<CommandParameter> p) {
-                return variable != null;
-            }
+        static RuleProcessor<SelectorCommandParameter> BlockCommandProcessor() {
+            var actionProcessor = requiredEither<ActionCommandParameter>();
+            var relativeProcessor = requiredEither<RelativeCommandParameter>();
+            var variableProcessor = requiredEither<VariableCommandParameter>();
+            var propertyProcessor = requiredEither<PropertyCommandParameter>();
+            var directionProcessor = requiredEither<DirectionCommandParameter>();
+            var reverseProcessor = requiredEither<ReverseCommandParameter>();
+            List<DataProcessor> processors = new List<DataProcessor> {
+                actionProcessor,
+                relativeProcessor,
+                variableProcessor,
+                propertyProcessor,
+                directionProcessor,
+                reverseProcessor
+            };
 
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                VariableAssignmentCommandParameter assignment = findFirst<VariableAssignmentCommandParameter>(p);
-                Command command = new VariableAssignmentCommand(assignment.variableName, variable, assignment.useReference);
+            CanConvert<SelectorCommandParameter> canConvert = (p) => processors.Exists(x => x.fetcher.Satisfied() && x != actionProcessor && x != relativeProcessor);
+            //TODO: Get rid of block handlers altogether
+            Convert<SelectorCommandParameter> convert = (p) => {
+                List<CommandParameter> commandParameters = new List<CommandParameter> { p };
+                if (relativeProcessor.f.HasValue()) commandParameters.Add(relativeProcessor.f.GetValue());
+                if (variableProcessor.f.HasValue()) commandParameters.Add(variableProcessor.f.GetValue());
+                if (propertyProcessor.f.HasValue()) commandParameters.Add(propertyProcessor.f.GetValue());
+                if (relativeProcessor.f.HasValue()) commandParameters.Add(relativeProcessor.f.GetValue());
+                if (directionProcessor.f.HasValue()) commandParameters.Add(directionProcessor.f.GetValue());
+                if (reverseProcessor.f.HasValue()) commandParameters.Add(reverseProcessor.f.GetValue());
+                BlockCommand command = new BlockCommand(commandParameters);
                 return new CommandReferenceParameter(command);
-            }
+            };
 
-            public override void Initialize() {
-                variable = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is VariableCommandParameter && variable == null) {
-                    variable = ((VariableCommandParameter)p).Value;
-                    return true;
-                } else return false;
-            }
+            return new RuleProcessor<SelectorCommandParameter>(processors, canConvert, convert);
         }
-
-        public class FunctionCallCommandProcessor : SimpleParameterProcessor<FunctionDefinitionCommandParameter> {
-            List<Variable> variables;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                FunctionDefinition function = findFirst<FunctionDefinitionCommandParameter>(p).functionDefinition;
-                return function.parameterNames.Count() == variables.Count;
-
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                FunctionDefinitionCommandParameter function = findFirst<FunctionDefinitionCommandParameter>(p);
-                FunctionDefinition definition = function.functionDefinition;
-                FunctionType functionType = function.functionType;
-                Dictionary<string, Variable> inputParameters = new Dictionary<string, Variable>();
-                for (int i = 0; i < definition.parameterNames.Count(); i++) {
-                    inputParameters[definition.parameterNames[i]] = variables[i];
-                }
-                Command command = new FunctionCommand(functionType, definition, inputParameters);
-                return new CommandReferenceParameter(command);
-            }
-
-            public override void Initialize() {
-                variables = new List<Variable>();
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is VariableCommandParameter) {
-                    variables.Add(((VariableCommandParameter)p).Value);
-                    return true;
-                } else return false;
-            }
-        }
-
-        public class QueueCommandProcessor : SimpleParameterProcessor<QueueCommandParameter> {
-            Command command = null;
-
-            public override void Initialize() {
-                command = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is CommandReferenceParameter && command == null) {
-                    command = ((CommandReferenceParameter)p).Value;
-                    return true;
-                }
-                return false;
-            }
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return command != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                bool Async = findFirst<QueueCommandParameter>(p).Value;
-                return new CommandReferenceParameter(new QueueCommand(command, Async));
-            }
-        }
-
-        public class ActionProcessor : SimpleParameterProcessor<SelectorCommandParameter> {
-            bool hasDirection, hasVariable, hasProperty, hasReverse, hasRelative, hasAction;
-
-            public override void Initialize() {
-                hasAction = false;
-                hasProperty = false;
-                hasVariable = false;
-                hasDirection = false;
-                hasRelative = false;
-                hasDirection = false;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return Process(p);
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                return Process(p);
-            }
-
-            private bool Process(CommandParameter p) {
-                if (p is DirectionCommandParameter && !hasDirection) hasDirection = true;
-                else if (p is VariableCommandParameter && !hasVariable) hasVariable = true;
-                else if (p is PropertyCommandParameter && !hasProperty) hasProperty = true;
-                else if (p is ReverseCommandParameter && !hasReverse) hasReverse = true;
-                else if (p is RelativeCommandParameter && !hasRelative) hasRelative = true;
-                else if ((p is ActionCommandParameter) && !hasAction) hasAction = true;
-                else return false;
-                return true;
-            }
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return hasVariable || hasProperty || hasDirection || hasReverse;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                BlockCommand command = new BlockCommand(p);
-                return new CommandReferenceParameter(command);
-            }
-        }
-
-        public class IteratorProcessor : SimpleParameterProcessor<IteratorCommandParameter> {
-            Variable iterations;
-            public override bool CanConvert(List<CommandParameter> p) {
-                return iterations != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                return new IterationCommandParameter(iterations);
-            }
-
-            public override void Initialize() {
-                iterations = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (p is VariableCommandParameter && iterations == null) {
-                    iterations = ((VariableCommandParameter)p).Value;
-                    return true;
-                }
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                return false;
-            }
-        }
-
-        public class IterationProcessor : SimpleParameterProcessor<IterationCommandParameter> {
-            Command command = null;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return command != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                IterationCommandParameter iterations = extractFirst<IterationCommandParameter>(p);
-                MultiActionCommand multiCommand = new MultiActionCommand(new List<Command>() { command }, iterations.Value);
-                return new CommandReferenceParameter(multiCommand);
-            }
-
-            public override void Initialize() {
-                command = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return Process(p);
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                return Process(p);
-            }
-
-            private bool Process(CommandParameter p) {
-                if (p is CommandReferenceParameter && command == null) {
-                    command = ((CommandReferenceParameter)p).Value;
-                    return true;
-                }
-                return false;
-            }
-        }
-
-        public class IfProcessor : SimpleParameterProcessor<IfCommandParameter> {
-            Variable condition;
-            public override bool CanConvert(List<CommandParameter> p) {
-                return condition != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                IfCommandParameter parameter = extractFirst<IfCommandParameter>(p);
-                if (parameter.inverseCondition) condition = new UniOperandVariable(UniOperandType.NOT, condition);
-
-                return new ConditionCommandParameter(condition, parameter.alwaysEvaluate, parameter.swapCommands);
-            }
-
-            public override void Initialize() {
-                condition = null;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if(p is VariableCommandParameter && condition == null) {
-                    condition = ((VariableCommandParameter)p).Value;
-                    return true;
-                }
-                return false;
-            }
-        }
-
-        public class ConditionalCommandProcessor : SimpleParameterProcessor<ConditionCommandParameter> {
-            Command conditionMetCommand, conditionNotMetCommand;
-            bool otherwise;
-
-            public override bool CanConvert(List<CommandParameter> p) {
-                return conditionMetCommand != null;
-            }
-
-            public override CommandParameter Convert(List<CommandParameter> p) {
-                ConditionCommandParameter condition = extractFirst<ConditionCommandParameter>(p);
-                if (conditionNotMetCommand == null) conditionNotMetCommand = new NullCommand(); 
-
-                if (condition.swapCommands) {
-                    var temp = conditionMetCommand;
-                    conditionMetCommand = conditionNotMetCommand;
-                    conditionNotMetCommand = temp;
-                }
-
-                Command command = new ConditionalCommand(condition.Value, conditionMetCommand, conditionNotMetCommand, condition.alwaysEvaluate);
-                return new CommandReferenceParameter(command);
-            }
-
-            public override void Initialize() {
-                conditionMetCommand = null;
-                conditionNotMetCommand = null;
-                otherwise = false;
-            }
-
-            public override bool ProcessLeft(CommandParameter p) {
-                if (p is CommandReferenceParameter && conditionMetCommand == null) {
-                    conditionMetCommand = ((CommandReferenceParameter)p).Value;
-                    return true;
-                } else return false;
-            }
-
-            public override bool ProcessRight(CommandParameter p) {
-                if (p is CommandReferenceParameter) {
-                    if (otherwise) {
-                        if (conditionNotMetCommand == null) {
-                            conditionNotMetCommand = ((CommandReferenceParameter)p).Value;
-                            return true;
-                        } else return false;
-                    } else {
-                        if (conditionMetCommand == null) {
-                            conditionMetCommand = ((CommandReferenceParameter)p).Value;
-                            return true;
-                        } else return false;
-                    }
-                } else if (p is ElseCommandParameter && !otherwise) {
-                    otherwise = true;
-                    return true;
-                } else return false;
-            }
-        }
-
     }
 }

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -25,7 +25,7 @@ namespace IngameScript {
         public enum UnitType { SECONDS, TICKS, DEGREES, RADIANS, METERS, RPM }
         public enum DirectionType { UP, DOWN, LEFT, RIGHT, FORWARD, BACKWARD, CLOCKWISE, COUNTERCLOCKWISE }
         public enum ComparisonType { GREATER, GREATER_OR_EQUAL, EQUAL, LESS_OR_EQUAL, LESS, NOT_EQUALS }
-        public enum ControlType { START, RESTART, STOP, REPEAT, PAUSE, RESUME }
+        public enum ControlType { START, RESTART, STOP, REPEAT, PAUSE }
         public enum ProgramState { RUNNING, STOPPED, COMPLETE, PAUSED }
         public enum FunctionType { GOTO, GOSUB, SWITCH }
         public enum PrimitiveType { NUMERIC, BOOLEAN, STRING, VECTOR, COLOR }


### PR DESCRIPTION
This commit significantly reduces expensive boilerplate code for ParameterProcessors by moving almost all processors to use a RuleProcessor and delegates.  This has
dramatically reduced the file and character size of ParameterProcessors.

I also added some missing tests for Iteration and Control command parameter processing.

I also removed some now unneeded constructors for some command types.

I also removed "Resume" as a specific control type and changed "Start" to act like Resume, as it had no purpose previously (was the same as Restart which didn't
quite make sense anyway).

Lastly, I changed the ParameterProcessor ranking to be set specifically be the list ordering instead of being inferred by type, as this was a problem for multiple
rule based processors that need to process the same type but maintain priority ordering for correctness.