### PR TITLE
Fixed Explicit Strings not working for Assignment and Function Calls

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
@@ -2,7 +2,7 @@
 using System;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests {
+namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class AggregateBlockPropertyProcessorTests {
         [TestMethod]

--- a/EasyCommands.Tests/ParameterParsingTests/BlockCommandProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/BlockCommandProcessorTests.cs
@@ -2,7 +2,7 @@
 using System;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests {
+namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class SimpleBlockCommandParameterProcessorTests {
         [TestMethod]

--- a/EasyCommands.Tests/ParameterParsingTests/BooleanLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/BooleanLogicParameterProcessorTests.cs
@@ -2,7 +2,7 @@
 using System;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests {
+namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class BooleanLogicParameterProcessorTests {
         [TestMethod]

--- a/EasyCommands.Tests/ParameterParsingTests/ConditionalParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/ConditionalParameterProcessorTests.cs
@@ -2,7 +2,7 @@
 using System;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests {
+namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class ConditionalParameterProcessorTests {
         [TestMethod]

--- a/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
@@ -3,7 +3,7 @@ using System;
 using VRageMath;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests {
+namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class OperatorParameterProcessorTests {
 

--- a/EasyCommands.Tests/ParameterParsingTests/ParenthesisParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/ParenthesisParameterProcessorTests.cs
@@ -2,7 +2,7 @@
 using System;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests {
+namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class ParenthesisParameterProcessorTests {
         [TestMethod]

--- a/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
@@ -2,7 +2,7 @@
 using System;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests {
+namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class SelectorLogicParameterProcessorTests {
         [TestMethod]

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleCommandProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleCommandProcessorTests.cs
@@ -5,7 +5,7 @@ using System.Collections;
 using System.Linq;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests {
+namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class SimpleCommandProcessorTests {
         [TestMethod]
@@ -54,6 +54,16 @@ namespace EasyCommands.Tests {
         }
 
         [TestMethod]
+        public void FunctionCommandFromExplicitString() {
+            FUNCTIONS["listen"] = new FunctionDefinition("listen", new List<string>());
+            var command = ParseCommand("goto 'listen'");
+            Assert.IsTrue(command is FunctionCommand);
+            FunctionCommand functionCommand = (FunctionCommand)command;
+            Assert.AreEqual("listen", functionCommand.functionDefinition.functionName);
+            Assert.AreEqual(FunctionType.GOTO, functionCommand.type);
+        }
+
+        [TestMethod]
         public void FunctionCommandWithParameters() {
             FUNCTIONS["listen"] = new FunctionDefinition("listen", new List<string>() { "a", "b" });
             var command = ParseCommand("goto \"listen\" 2 3");
@@ -90,40 +100,6 @@ namespace EasyCommands.Tests {
             WaitCommand waitCommand = (WaitCommand)command;
             Assert.AreEqual(3, CastNumber(waitCommand.waitInterval.GetValue()).GetNumericValue());
             Assert.AreEqual(UnitType.TICKS, waitCommand.units);
-        }
-
-        [TestMethod]
-        public void AssignVariable() {
-            var command = ParseCommand("assign \"a\" to 2");
-            Assert.IsTrue(command is VariableAssignmentCommand);
-            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand) command;
-            Assert.AreEqual("a", assignCommand.variableName);
-            Assert.AreEqual(2, CastNumber(assignCommand.variable.GetValue()).GetNumericValue());
-            Assert.IsFalse(assignCommand.useReference);
-        }
-
-        [TestMethod]
-        public void AssignVariableCaseIsPreserved() {
-            var command = ParseCommand("assign \"a\" to {variableName}");
-            Assert.IsTrue(command is VariableAssignmentCommand);
-            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
-            Assert.AreEqual("a", assignCommand.variableName);
-            Assert.IsTrue(assignCommand.variable is InMemoryVariable);
-            InMemoryVariable memoryVariable = (InMemoryVariable)assignCommand.variable;
-            Assert.AreEqual("variableName", memoryVariable.variableName);
-        }
-
-        [TestMethod]
-        public void LockVariable() {
-            var command = ParseCommand("bind \"a\" to {b} is 2");
-            Assert.IsTrue(command is VariableAssignmentCommand);
-            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
-            Assert.AreEqual("a", assignCommand.variableName);
-            Assert.IsTrue(assignCommand.variable is ComparisonVariable);
-            Assert.IsTrue(assignCommand.useReference);
-
-            ComparisonVariable comparison = (ComparisonVariable)assignCommand.variable;
-            Assert.IsTrue(comparison.a is InMemoryVariable);
         }
 
         [TestMethod]

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
@@ -8,6 +8,51 @@ namespace EasyCommands.Tests.ParameterParsingTests {
     public class SimpleVariableParameterProcessorTests {
 
         [TestMethod]
+        public void AssignVariable() {
+            var command = ParseCommand("assign \"a\" to 2");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("a", assignCommand.variableName);
+            Assert.AreEqual(2, CastNumber(assignCommand.variable.GetValue()).GetNumericValue());
+            Assert.IsFalse(assignCommand.useReference);
+        }
+
+
+        [TestMethod]
+        public void AssignVariableFromExplicitString() {
+            var command = ParseCommand("assign 'a' to 2");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("a", assignCommand.variableName);
+            Assert.AreEqual(2, CastNumber(assignCommand.variable.GetValue()).GetNumericValue());
+            Assert.IsFalse(assignCommand.useReference);
+        }
+
+        [TestMethod]
+        public void AssignVariableCaseIsPreserved() {
+            var command = ParseCommand("assign \"a\" to {variableName}");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("a", assignCommand.variableName);
+            Assert.IsTrue(assignCommand.variable is InMemoryVariable);
+            InMemoryVariable memoryVariable = (InMemoryVariable)assignCommand.variable;
+            Assert.AreEqual("variableName", memoryVariable.variableName);
+        }
+
+        [TestMethod]
+        public void LockVariable() {
+            var command = ParseCommand("bind \"a\" to {b} is 2");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("a", assignCommand.variableName);
+            Assert.IsTrue(assignCommand.variable is ComparisonVariable);
+            Assert.IsTrue(assignCommand.useReference);
+
+            ComparisonVariable comparison = (ComparisonVariable)assignCommand.variable;
+            Assert.IsTrue(comparison.a is InMemoryVariable);
+        }
+
+        [TestMethod]
         public void ParseSimpleVector() {
             var command = ParseCommand("assign a to \"53573.9750085028:-26601.8512032533:12058.8229348438\"");
             Assert.IsTrue(command is VariableAssignmentCommand);

--- a/EasyCommands.Tests/TokenParsingTests/StringParsingTests.cs
+++ b/EasyCommands.Tests/TokenParsingTests/StringParsingTests.cs
@@ -2,7 +2,7 @@
 using System;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests {
+namespace EasyCommands.Tests.TokenParsingTests {
     [TestClass]
     public class StringParsingTests {
         [TestMethod]

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -408,7 +408,7 @@ namespace IngameScript {
                 String t = token.token;
 
                 if(token.isExplicitString) {
-                    commandParameters.Add(new VariableCommandParameter(new StaticVariable(new StringPrimitive(token.original))));
+                    commandParameters.Add(new ExplicitStringCommandParameter(token.original));
                     continue;
                 }
 

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -34,10 +34,20 @@ namespace IngameScript {
                         if(!FUNCTIONS.TryGetValue(name.GetValue().Value, out definition)) throw new Exception("Unknown function: " + name.GetValue().Value);
                         return new FunctionDefinitionCommandParameter(p.Value, definition);
                     }),
+                OneValueRule<FunctionCommandParameter,ExplicitStringCommandParameter>(
+                    requiredRight<ExplicitStringCommandParameter>(),
+                    (p,name) => {
+                        FunctionDefinition definition;
+                        if(!FUNCTIONS.TryGetValue(name.GetValue().Value, out definition)) throw new Exception("Unknown function: " + name.GetValue().Value);
+                        return new FunctionDefinitionCommandParameter(p.Value, definition);
+                    }),
 
                 //AssignmentProcessor
                 OneValueRule<AssignmentCommandParameter,StringCommandParameter>(
                     requiredRight<StringCommandParameter>(),
+                    (p,name) => new VariableAssignmentCommandParameter(name.GetValue().Value, p.useReference)),
+                OneValueRule<AssignmentCommandParameter,ExplicitStringCommandParameter>(
+                    requiredRight<ExplicitStringCommandParameter>(),
                     (p,name) => new VariableAssignmentCommandParameter(name.GetValue().Value, p.useReference)),
 
                 //SelfSelectorProcessor
@@ -477,18 +487,12 @@ namespace IngameScript {
 
         public class PrimitiveProcessor : ParameterProcessor<PrimitiveCommandParameter> {
             public override List<Type> GetProcessedTypes() {
-                return new List<Type>() { typeof(StringCommandParameter), typeof(NumericCommandParameter), typeof(BooleanCommandParameter) };
+                return new List<Type>() { typeof(StringCommandParameter), typeof(NumericCommandParameter), typeof(BooleanCommandParameter), typeof(ExplicitStringCommandParameter) };
             }
 
             public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters) {
-                if (p[i] is StringCommandParameter) {
-                    String value = ((StringCommandParameter)p[i]).Value;
-                    Primitive primitive = new StringPrimitive(value);
-                    Vector3D vector;
-                    if (GetVector(value, out vector)) primitive = new VectorPrimitive(vector);
-                    Color color;
-                    if (GetColor(value, out color)) primitive = new ColorPrimitive(color);
-                    p[i] = new VariableCommandParameter(new StaticVariable(primitive));
+                if (p[i] is ValueCommandParameter<String>) {
+                    p[i] = GetParameter(((ValueCommandParameter<String>)p[i]).Value);
                 } else if (p[i] is NumericCommandParameter) {
                     p[i] = new VariableCommandParameter(new StaticVariable(new NumberPrimitive(((NumericCommandParameter)p[i]).Value)));
                 } else if (p[i] is BooleanCommandParameter) {
@@ -499,6 +503,15 @@ namespace IngameScript {
                 }
                 finalParameters = new List<CommandParameter>() { p[i] };
                 return true;
+            }
+
+            VariableCommandParameter GetParameter(String value) {
+                Primitive primitive = new StringPrimitive(value);
+                Vector3D vector;
+                if (GetVector(value, out vector)) primitive = new VectorPrimitive(vector);
+                Color color;
+                if (GetColor(value, out color)) primitive = new ColorPrimitive(color);
+                return new VariableCommandParameter(new StaticVariable(primitive));
             }
         }
 

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -133,6 +133,10 @@ namespace IngameScript {
             }
         }
 
+        public class ExplicitStringCommandParameter : ValueCommandParameter<String>, PrimitiveCommandParameter {
+            public ExplicitStringCommandParameter(string value) : base(value) {}
+        }
+
         public class NumericCommandParameter : ValueCommandParameter<float>, PrimitiveCommandParameter {
             public NumericCommandParameter(float value) : base(value) {}
         }


### PR DESCRIPTION
This fix, built on top of pull #35 , fixes an outstanding bug where you can't assign variables or call functions using an explicit string.

Specifically, this commit fixes #27
This commit also moves all the processor tests to the correct namespace and moves the variable assignment tests into SimpleVariableParamterProcessorTests