### PR TITLE
Added target support to Camera and Sensor Blocks

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -120,6 +120,7 @@
     <Compile Include="ParameterParsingTests\OperatorParameterProcessorTests.cs" />
     <Compile Include="ParameterParsingTests\SimpleVariableParameterProcessorTests.cs" />
     <Compile Include="ParameterParsingTests\AggregateBlockPropertyProcessorTests.cs" />
+    <Compile Include="ScriptTests\MockEntityUtility.cs" />
     <Compile Include="ScriptTests\ConditionalBlockExecutionTests.cs" />
     <Compile Include="ParameterParsingTests\BlockCommandProcessorTests.cs" />
     <Compile Include="ParameterParsingTests\BooleanLogicParameterProcessorTests.cs" />
@@ -132,6 +133,8 @@
     <Compile Include="ScriptTests\SimpleCommandExecutionTests.cs" />
     <Compile Include="ScriptTests\SimpleBlockCommandTests.cs" />
     <Compile Include="ScriptTests\MultiThreadingTests.cs" />
+    <Compile Include="ScriptTests\CameraBlockTests.cs" />
+    <Compile Include="ScriptTests\SensorBlockTests.cs" />
     <Compile Include="TokenParsingTests\StringParsingTests.cs" />
     <Compile Include="TokenParsingTests\ParenthesisParsingTests.cs" />
     <Compile Include="Util\Extensions.cs" />

--- a/EasyCommands.Tests/ScriptTests/CameraBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/CameraBlockTests.cs
@@ -1,0 +1,164 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+using VRageMath;
+using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class CameraBlockTests {
+        [TestMethod]
+        public void getCameraRange() {
+            String script = @"
+assign ""a"" to avg ""mock camera"" range
+print ""Range: "" + {a}
+";
+            using (var test = new ScriptTest(script)) {
+                var mockCamera = new Mock<IMyCameraBlock>();
+                mockCamera.Setup(b => b.CustomData).Returns("Range=200");
+
+                test.MockBlocksOfType("mock camera", mockCamera);
+                test.RunUntilDone();
+
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Range: 200", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void setCameraRange() {
+            String script = @"
+set the ""mock camera"" range to 200
+";
+            using (var test = new ScriptTest(script)) {
+                var mockCamera = new Mock<IMyCameraBlock>();
+
+                mockCamera.Setup(c => c.CustomData).Returns("");
+                test.MockBlocksOfType("mock camera", mockCamera);
+                test.RunUntilDone();
+
+                mockCamera.VerifySet(c => c.CustomData = "Range=200");
+            }
+        }
+
+        [TestMethod]
+        public void triggerTheCamera() {
+            String script = @"
+trigger the ""mock camera""
+";
+            using (var test = new ScriptTest(script)) {
+                var mockCamera = new Mock<IMyCameraBlock>();
+
+                test.MockBlocksOfType("mock camera", mockCamera);
+                test.RunUntilDone();
+
+                mockCamera.VerifySet(c => c.EnableRaycast = true);
+            }
+        }
+
+        [TestMethod]
+        public void cameraIsTriggeredGetTarget() {
+            String script = @"
+when ""mock camera"" is triggered
+  print ""Target: "" + avg ""mock camera"" target
+";
+            using (var test = new ScriptTest(script)) {
+                var mockCamera = new Mock<IMyCameraBlock>();
+                mockCamera.Setup(b => b.CustomData).Returns("");
+                mockCamera.Setup(b => b.CanScan(1000)).Returns(false);
+
+                test.MockBlocksOfType("mock camera", mockCamera);
+                test.RunOnce();
+
+                Assert.AreEqual(0, test.Logger.Count);
+                mockCamera.VerifySet(b => b.EnableRaycast = true);
+                mockCamera.Verify(b => b.CanScan(1000));
+
+                test.RunOnce();
+
+                Assert.AreEqual(0, test.Logger.Count);
+                mockCamera.Verify(b => b.CanScan(1000));
+
+                mockCamera.Setup(b => b.CanScan(1000)).Returns(true);
+                mockCamera.Setup(b => b.Raycast(1000,0,0)).Returns(MockDetectedEntity(new Vector3D(1, 2, 3)));
+                mockCamera.Setup(b => b.CustomData).Returns("Target=1:2:3");
+                test.RunOnce();
+
+                mockCamera.VerifySet(b => b.CustomData = "Target=1:2:3");
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Target: 1:2:3", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void LastTargetIsStillAvailableWhenCannotScan() {
+            String script = @"
+print ""Target: "" + avg ""mock camera"" target
+";
+            using (var test = new ScriptTest(script)) {
+                var mockCamera = new Mock<IMyCameraBlock>();
+                mockCamera.Setup(b => b.CanScan(1000)).Returns(false);
+                mockCamera.Setup(b => b.CustomData).Returns("Target=1:2:3");
+
+                test.MockBlocksOfType("mock camera", mockCamera);
+                test.RunOnce();
+                mockCamera.VerifySet(b => b.EnableRaycast = true);
+                mockCamera.Verify(b => b.CanScan(1000));
+
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Target: 1:2:3", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void NoTargetReturnsZeroVector() {
+            String script = @"
+print ""Target: "" + avg ""mock camera"" target
+";
+            using (var test = new ScriptTest(script)) {
+                var mockCamera = new Mock<IMyCameraBlock>();
+                mockCamera.Setup(b => b.CustomData).Returns("");
+                mockCamera.Setup(b => b.CanScan(1000)).Returns(false);
+
+                test.MockBlocksOfType("mock camera", mockCamera);
+                test.RunOnce();
+                mockCamera.VerifySet(b => b.EnableRaycast = true);
+                mockCamera.Verify(b => b.CanScan(1000));
+
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Target: 0:0:0", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void NoScannedTargetDeletesPreviouslyStoredTarget() {
+            String script = @"
+print ""Target: "" + avg ""mock camera"" target
+";
+            using (var test = new ScriptTest(script)) {
+                var mockCamera = new Mock<IMyCameraBlock>();
+                mockCamera.Setup(b => b.CanScan(1000)).Returns(false);
+                mockCamera.Setup(b => b.CustomData).Returns("Target=1:2:3");
+
+                test.MockBlocksOfType("mock camera", mockCamera);
+                test.RunOnce();
+                mockCamera.VerifySet(b => b.EnableRaycast = true);
+                mockCamera.Verify(b => b.CanScan(1000));
+
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Target: 1:2:3", test.Logger[0]);
+
+                test.Logger.Clear();
+                mockCamera.Setup(b => b.CanScan(1000)).Returns(true);
+                mockCamera.Setup(b => b.Raycast(1000, 0, 0)).Returns(MockNoDetectedEntity());
+                mockCamera.Setup(b => b.CustomData).Returns("");
+                test.RunOnce();
+
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Target: 0:0:0", test.Logger[0]);
+                mockCamera.VerifySet(b => b.CustomData = "");
+            }
+        }
+    }
+}

--- a/EasyCommands.Tests/ScriptTests/MockEntityUtility.cs
+++ b/EasyCommands.Tests/ScriptTests/MockEntityUtility.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Sandbox.ModAPI.Ingame;
+using VRageMath;
+
+namespace EasyCommands.Tests.ScriptTests {
+    class MockEntityUtility {
+
+        public static MyDetectedEntityInfo MockDetectedEntity(Vector3D position) {
+            return new MyDetectedEntityInfo(123, "name", MyDetectedEntityType.LargeGrid, position,
+                new MatrixD(), Vector3D.Zero, VRage.Game.MyRelationsBetweenPlayerAndBlock.Neutral, new BoundingBoxD(), 123);
+        }
+
+        public static MyDetectedEntityInfo MockNoDetectedEntity() {
+            return new MyDetectedEntityInfo();
+        }
+    }
+}

--- a/EasyCommands.Tests/ScriptTests/SensorBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SensorBlockTests.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+using VRageMath;
+using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class SensorBlockTests {
+        [TestMethod]
+        public void SensorTargetReturnsZeroVectorWhenNothingDetected() {
+            String script = @"
+print ""Target: "" + avg ""mock sensor"" target
+";
+            using (var test = new ScriptTest(script)) {
+                var mockSensor = new Mock<IMySensorBlock>();
+                mockSensor.Setup(b => b.CustomData).Returns("");
+                mockSensor.Setup(b => b.LastDetectedEntity).Returns(MockNoDetectedEntity());
+
+                test.MockBlocksOfType("mock sensor", mockSensor);
+                test.RunOnce();
+
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Target: 0:0:0", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void TriggerTheSensorAndGetTarget() {
+            String script = @"
+when ""mock sensor"" is triggered
+  print ""Target: "" + avg ""mock sensor"" target
+";
+            using (var test = new ScriptTest(script)) {
+                var mockSensor = new Mock<IMySensorBlock>();
+                mockSensor.Setup(b => b.CustomData).Returns("");
+                mockSensor.Setup(b => b.IsActive).Returns(false);
+
+                test.MockBlocksOfType("mock sensor", mockSensor);
+                test.RunOnce();
+
+                Assert.AreEqual(0, test.Logger.Count);
+
+                test.RunOnce();
+
+                Assert.AreEqual(0, test.Logger.Count);
+
+                mockSensor.Setup(b => b.IsActive).Returns(true);
+                mockSensor.Setup(b => b.LastDetectedEntity).Returns(MockDetectedEntity(new Vector3D(1, 2, 3)));
+                test.RunOnce();
+
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Target: 1:2:3", test.Logger[0]);
+            }
+        }
+    }
+}

--- a/EasyCommands/BlockHandlers/BlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/BlockHandlers.cs
@@ -256,13 +256,18 @@ namespace IngameScript {
 
             protected override string Name(T block) { return block.CustomName; }
 
-            protected String GetCustomProperty(T block, String key) { return GetCustomData(block).GetValueOrDefault(key); }
+            protected String GetCustomProperty(T block, String key) { return GetCustomData(block).GetValueOrDefault(key, null); }
             protected void SetCustomProperty(T block, String key, String value) {
                 Dictionary<String, String> d = GetCustomData(block);
                 d[key] = value;SaveCustomData(block, d);
             }
+            protected void DeleteCustomProperty(T block, String key) {
+                Dictionary<String, String> d = GetCustomData(block);
+                if(d.ContainsKey(key)) d.Remove(key);
+                SaveCustomData(block, d);
+            }
             protected void SaveCustomData(T block, Dictionary<String, String> data) {
-                block.CustomData = String.Join("\n",data.Keys.Select(k => k + "=" + data[k] + '\n').ToList());
+                block.CustomData = String.Join("\n",data.Keys.Select(k => k + "=" + data[k]).ToList());
             }
             protected Dictionary<String, String> GetCustomData(T block) {
                 List<String> keys = block.CustomData.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
@@ -353,6 +358,10 @@ namespace IngameScript {
 
             protected void AddNumericHandler(PropertyType property, GetNumericProperty<T> Get, SetNumericProperty<T> Set, float delta) {
                 propertyHandlers[property] = new SimpleNumericPropertyHandler<T>(Get, Set, delta);
+            }
+
+            protected void AddVectorHandler(PropertyType property, GetVectorProperty<T> Get) {
+                propertyHandlers[property] = new SimpleVectorPropertyHandler<T>(Get, (b,v) => { });
             }
 
             protected void AddVectorHandler(PropertyType property, GetVectorProperty<T> Get, SetVectorProperty<T> Set) {

--- a/EasyCommands/BlockHandlers/SensorBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/SensorBlockHandlers.cs
@@ -22,6 +22,13 @@ namespace IngameScript {
         public class SensorBlockHandler : FunctionalBlockHandler<IMySensorBlock> {
             public SensorBlockHandler() {
                 AddBooleanHandler(PropertyType.TRIGGER, (b) => b.IsActive);
+                AddVectorHandler(PropertyType.TARGET, (b) => {
+                    MyDetectedEntityInfo lastDetectedEntity = b.LastDetectedEntity;
+                    Vector3D hitPosition = Vector3D.Zero;
+                    if (!lastDetectedEntity.IsEmpty()) hitPosition = lastDetectedEntity.HitPosition.Value;
+                    return hitPosition;
+                });
+
                 defaultPropertiesByPrimitive[PrimitiveType.BOOLEAN] = PropertyType.TRIGGER;
             }
         }

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -92,12 +92,12 @@ namespace IngameScript {
             AddBiOperation<string, string>(BiOperandType.ADD, (a, b) => a + b);
             AddBiOperation<string, bool>(BiOperandType.ADD, (a, b) => a + b);
             AddBiOperation<string, float>(BiOperandType.ADD, (a, b) => a + b);
-            AddBiOperation<string, Vector3D>(BiOperandType.ADD, (a, b) => a + ToString(b));
+            AddBiOperation<string, Vector3D>(BiOperandType.ADD, (a, b) => a + VectorToString(b));
             AddBiOperation<string, Color>(BiOperandType.ADD, (a, b) => b + a.ToString());
             AddBiOperation<bool, string>(BiOperandType.ADD, (a, b) => a + b);
             AddBiOperation<float, string>(BiOperandType.ADD, (a, b) => a + b);
             AddBiOperation<Color, string>(BiOperandType.ADD, (a, b) => a.ToString() + b);
-            AddBiOperation<Vector3D, string>(BiOperandType.ADD, (a, b) => ToString(a) + b);
+            AddBiOperation<Vector3D, string>(BiOperandType.ADD, (a, b) => VectorToString(a) + b);
             AddBiOperation<string, string>(BiOperandType.SUBTACT, (a, b) => a.Replace(b, ""));
             AddBiOperation<string, string>(BiOperandType.MOD, (a, b) => a.Replace(b, ""));
             AddBiOperation<string, float>(BiOperandType.SUBTACT, (a, b) => a.Substring(Convert.ToInt32(b)));

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -114,9 +114,9 @@ namespace IngameScript {
         public static StringPrimitive CastString(Primitive p) {
             switch (p.GetPrimitiveType()) {
                 case PrimitiveType.VECTOR:
-                    return new StringPrimitive(ToString(CastVector(p).GetVectorValue()));
+                    return new StringPrimitive(VectorToString(CastVector(p).GetVectorValue()));
                 case PrimitiveType.COLOR:
-                    return new StringPrimitive(ToString(CastColor(p).GetColorValue()));
+                    return new StringPrimitive(ColorToString(CastColor(p).GetColorValue()));
                 default: return new StringPrimitive(p.GetValue().ToString());
             }
         }
@@ -170,11 +170,11 @@ namespace IngameScript {
             return true;
         }
 
-        static string ToString(Vector3D vector) {
+        static string VectorToString(Vector3D vector) {
             return vector.X + ":" + vector.Y + ":" + vector.Z;
         }
 
-        static string ToString(Color color) {
+        static string ColorToString(Color color) {
             return "#" + IntToHex(color.R) + IntToHex(color.G) + IntToHex(color.B);
         }
 


### PR DESCRIPTION
This commit adds basic target support for Camera and Sensor Blocks
It also fixed a couple bugs with getting and setting custom properties which were discovered during testing.

Also adds block handler tests for Camera and Sensor Blocks along with a MockEntityUtility for adding commonly used mocks in the future.

This implements #30 