### PR TITLE
Fixed Bug with Rotor angle not honoring direction

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="ScriptTests\SimpleCommandExecutionTests.cs" />
     <Compile Include="ScriptTests\SimpleBlockCommandTests.cs" />
     <Compile Include="ScriptTests\MultiThreadingTests.cs" />
+    <Compile Include="ScriptTests\RotorBlockTests.cs" />
     <Compile Include="TokenParsingTests\StringParsingTests.cs" />
     <Compile Include="TokenParsingTests\ParenthesisParsingTests.cs" />
     <Compile Include="Util\Extensions.cs" />

--- a/EasyCommands.Tests/ScriptTests/RotorBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/RotorBlockTests.cs
@@ -1,0 +1,200 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+using VRageMath;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class RotorBlockTests {
+        [TestMethod]
+        public void setRotorAngleGreaterThanMovesClockwise() {
+            String script = @"
+rotate the ""rotor"" to 30
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+
+                mockRotor.Setup(r => r.TargetVelocityRPM).Returns(1);
+                mockRotor.Setup(r => r.Angle).Returns(0);
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.UpperLimitDeg = 30);
+                mockRotor.VerifySet(b => b.TargetVelocityRPM = 1);
+            }
+        }
+
+        [TestMethod]
+        public void setRotorAngleLessThanMovesCounterClockwise() {
+            String script = @"
+rotate the ""rotor"" to -30
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+
+                mockRotor.Setup(r => r.TargetVelocityRPM).Returns(1);
+                mockRotor.Setup(r => r.Angle).Returns(0);
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.LowerLimitDeg = -30);
+                mockRotor.VerifySet(b => b.TargetVelocityRPM = -1);
+            }
+        }
+
+        [TestMethod]
+        public void increaseRotorAngle() {
+            String script = @"
+rotate the ""rotor"" clockwise by 30
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+
+                mockRotor.Setup(r => r.TargetVelocityRPM).Returns(1);
+                mockRotor.Setup(r => r.Angle).Returns(0);
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.UpperLimitDeg = 30);
+                mockRotor.VerifySet(b => b.TargetVelocityRPM = 1);
+            }
+        }
+
+        [TestMethod]
+        public void increaseRotorAngleWrapsAround() {
+            String script = @"
+rotate the ""rotor"" clockwise by 30
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+
+                mockRotor.Setup(r => r.TargetVelocityRPM).Returns(1);
+                mockRotor.Setup(r => r.Angle).Returns(345 * (float)Math.PI / 180);
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.UpperLimitDeg = 15.0000305f); //Oh floats and rounding...
+                mockRotor.VerifySet(b => b.TargetVelocityRPM = 1);
+            }
+        }
+
+        [TestMethod]
+        public void decreaseRotorAngle() {
+            String script = @"
+rotate the ""rotor"" counterclockwise by 30
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+
+                mockRotor.Setup(r => r.TargetVelocityRPM).Returns(1);
+                mockRotor.Setup(r => r.Angle).Returns(0);
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.LowerLimitDeg = -30);
+                mockRotor.VerifySet(b => b.TargetVelocityRPM = -1);
+            }
+        }
+
+        [TestMethod]
+        public void decreaseRotorAngleWrapsAround() {
+            String script = @"
+rotate the ""rotor"" counterclockwise by 30
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+
+                mockRotor.Setup(r => r.TargetVelocityRPM).Returns(1);
+                mockRotor.Setup(r => r.Angle).Returns(-345 * (float)Math.PI / 180);
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.LowerLimitDeg = -15.0000305f); //Oh floats and rounding...
+                mockRotor.VerifySet(b => b.TargetVelocityRPM = -1);
+            }
+        }
+
+        [TestMethod]
+        public void setRotorAngleClockwise() {
+            String script = @"
+rotate the ""rotor"" 30 clockwise
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+
+                mockRotor.Setup(r => r.TargetVelocityRPM).Returns(1);
+                mockRotor.Setup(r => r.Angle).Returns(0);
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.UpperLimitDeg = 30);
+                mockRotor.VerifySet(b => b.TargetVelocityRPM = 1);
+            }
+        }
+
+        [TestMethod]
+        public void setRotorAngleCounterClockwise() {
+            String script = @"
+rotate the ""rotor"" -30 counterclockwise
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+
+                mockRotor.Setup(r => r.TargetVelocityRPM).Returns(1);
+                mockRotor.Setup(r => r.Angle).Returns(0);
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.LowerLimitDeg = -30);
+                mockRotor.VerifySet(b => b.TargetVelocityRPM = -1);
+            }
+        }
+
+        [TestMethod]
+        public void setRotorAngleClockwiseWrapsAround() {
+            String script = @"
+rotate the ""rotor"" -60 clockwise
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+
+                mockRotor.Setup(r => r.TargetVelocityRPM).Returns(1);
+                mockRotor.Setup(r => r.Angle).Returns(-30 * (float)Math.PI / 180);
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.UpperLimitDeg = 300);
+                mockRotor.VerifySet(b => b.TargetVelocityRPM = 1);
+            }
+        }
+
+        [TestMethod]
+        public void setRotorAngleCounterClockwiseWrapsAround() {
+            String script = @"
+rotate the ""rotor"" 60 counterclockwise
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+
+                mockRotor.Setup(r => r.TargetVelocityRPM).Returns(1);
+                mockRotor.Setup(r => r.Angle).Returns(30 * (float)Math.PI / 180);
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.LowerLimitDeg= -300);
+                mockRotor.VerifySet(b => b.TargetVelocityRPM = -1);
+            }
+        }
+    }
+}

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -606,7 +606,6 @@ namespace IngameScript {
                 if (relativeProcessor.f.HasValue()) commandParameters.Add(relativeProcessor.f.GetValue());
                 if (variableProcessor.f.HasValue()) commandParameters.Add(variableProcessor.f.GetValue());
                 if (propertyProcessor.f.HasValue()) commandParameters.Add(propertyProcessor.f.GetValue());
-                if (relativeProcessor.f.HasValue()) commandParameters.Add(relativeProcessor.f.GetValue());
                 if (directionProcessor.f.HasValue()) commandParameters.Add(directionProcessor.f.GetValue());
                 if (reverseProcessor.f.HasValue()) commandParameters.Add(reverseProcessor.f.GetValue());
                 BlockCommand command = new BlockCommand(commandParameters);

--- a/EasyCommands/Commands/Commands.cs
+++ b/EasyCommands/Commands/Commands.cs
@@ -282,7 +282,7 @@ namespace IngameScript {
                     }),
                     new BlockCommandHandler2<DirectionCommandParameter, VariableCommandParameter>((b,e,d,v)=>{
                         PropertyType property = b.GetDefaultProperty(d.Value);
-                        b.SetPropertyValue(e, property, v.Value.GetValue());
+                        b.SetPropertyValue(e, property, d.Value, v.Value.GetValue());
                     }),
                     new BlockCommandHandler3<PropertyCommandParameter, DirectionCommandParameter, VariableCommandParameter>((b,e,p,d,v)=>{
                         b.SetPropertyValue(e,p.Value,d.Value,v.Value.GetValue());

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -38,7 +38,7 @@ namespace IngameScript {
             }
 
             public Primitive Minus(Primitive p) {
-                return PerformOperation(BiOperandType.ADD, this, p);
+                return PerformOperation(BiOperandType.SUBTACT, this, p);
             }
 
             public Primitive Multiply(Primitive p) {


### PR DESCRIPTION
This commit mostly fixes the issue with rotor angle not obeying directions.  It turns out there are some cases where the game itself won't properly wrap around.
I added tests for the cases where obeying direction should now work.

I found multiple bugs introduced by previous changes as part of this which also had to be fixed, including:
* Subtraction Operation was not working correctly (was adding)
* SetPropertyDirection was ignoring direction for all blocks, not just rotors
* Increment/Decrement commands were broken as the relative command parameter was passed to BlockCommand twice.

This commit fixes #14 