### PR TITLE
Added "all" and implicit selector support

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
@@ -94,5 +94,17 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             AggregatePropertyVariable aggregate = (AggregatePropertyVariable)assignCommand.variable;
             Assert.AreEqual(PropertyAggregatorType.AVG, aggregate.aggregationType);
         }
+
+        [TestMethod]
+        public void AssignAvgOfBlocksUsingImplicitSelector() {
+            var command = ParseCommand("assign \"a\" to the average gun range");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
+            AggregatePropertyVariable aggregate = (AggregatePropertyVariable)assignCommand.variable;
+            Assert.AreEqual(PropertyAggregatorType.AVG, aggregate.aggregationType);
+            Assert.IsTrue(aggregate.entityProvider is AllEntityProvider);
+            Assert.AreEqual(BlockType.GUN, aggregate.entityProvider.GetBlockType());
+        }
     }
 }

--- a/EasyCommands.Tests/ParameterParsingTests/BooleanLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/BooleanLogicParameterProcessorTests.cs
@@ -58,5 +58,48 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             var command = ParseCommand("if not all of the \"batteries\" ratio > 0.75 turn on the \"generators\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
+
+        [TestMethod]
+        public void ImplicitSelectorUsedInAggregateCondition() {
+            var command = ParseCommand("if any battery ratio < 0.75 turn on the generators");
+            Assert.IsTrue(command is ConditionalCommand);
+            ConditionalCommand conditionalCommand = (ConditionalCommand)command;
+            Assert.IsTrue(conditionalCommand.Condition is AggregateConditionVariable);
+            AggregateConditionVariable condition = (AggregateConditionVariable)conditionalCommand.Condition;
+            Assert.IsTrue(condition.entityProvider is AllEntityProvider);
+            Assert.AreEqual(BlockType.BATTERY, condition.entityProvider.GetBlockType());
+            Assert.AreEqual(AggregationMode.ANY, condition.aggregationMode);
+            Assert.IsTrue(condition.blockCondition is BlockPropertyCondition);
+            BlockPropertyCondition propertyCondition = (BlockPropertyCondition)condition.blockCondition;
+            Assert.AreEqual(PropertyType.RATIO, propertyCondition.property);
+
+            Assert.IsTrue(conditionalCommand.conditionMetCommand is BlockCommand);
+            BlockCommand metCommand = (BlockCommand)conditionalCommand.conditionMetCommand;
+            Assert.IsTrue(metCommand.entityProvider is AllEntityProvider);
+            Assert.AreEqual(BlockType.GENERATOR, metCommand.entityProvider.GetBlockType());
+        }
+
+        [TestMethod]
+        public void ImplicitSelectorUsedInAggregateConditionWithNot() {
+            var command = ParseCommand("if not all of the batteries ratio < 0.75 turn on the generators");
+            Assert.IsTrue(command is ConditionalCommand);
+            ConditionalCommand conditionalCommand = (ConditionalCommand)command;
+            Assert.IsTrue(conditionalCommand.Condition is UniOperandVariable);
+            UniOperandVariable variable = (UniOperandVariable)conditionalCommand.Condition;
+            Assert.AreEqual(UniOperandType.NOT, variable.operand);
+            Assert.IsTrue(variable.a is AggregateConditionVariable);
+            AggregateConditionVariable condition = (AggregateConditionVariable)variable.a;
+            Assert.IsTrue(condition.entityProvider is AllEntityProvider);
+            Assert.AreEqual(BlockType.BATTERY, condition.entityProvider.GetBlockType());
+            Assert.AreEqual(AggregationMode.ALL, condition.aggregationMode);
+            Assert.IsTrue(condition.blockCondition is BlockPropertyCondition);
+            BlockPropertyCondition propertyCondition = (BlockPropertyCondition)condition.blockCondition;
+            Assert.AreEqual(PropertyType.RATIO, propertyCondition.property);
+
+            Assert.IsTrue(conditionalCommand.conditionMetCommand is BlockCommand);
+            BlockCommand metCommand = (BlockCommand)conditionalCommand.conditionMetCommand;
+            Assert.IsTrue(metCommand.entityProvider is AllEntityProvider);
+            Assert.AreEqual(BlockType.GENERATOR, metCommand.entityProvider.GetBlockType());
+        }
     }
 }

--- a/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
@@ -96,5 +96,57 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.IsTrue(iep.provider is SelfEntityProvider);
             Assert.AreEqual(BlockType.DISPLAY, iep.provider.GetBlockType());
         }
+
+        [TestMethod]
+        public void AllSelector() {
+            var command = ParseCommand("set all piston height to 0");
+            Assert.IsTrue(command is BlockCommand);
+            BlockCommand bc = (BlockCommand)command;
+            Assert.IsTrue(bc.entityProvider is AllEntityProvider);
+            AllEntityProvider aep = (AllEntityProvider)bc.entityProvider;
+            Assert.AreEqual(BlockType.PISTON, aep.GetBlockType());
+        }
+
+        [TestMethod]
+        public void AllSelectorGroup() {
+            var command = ParseCommand("set the height of all pistons to 0");
+            Assert.IsTrue(command is BlockCommand);
+            BlockCommand bc = (BlockCommand)command;
+            Assert.IsTrue(bc.entityProvider is AllEntityProvider);
+            AllEntityProvider aep = (AllEntityProvider)bc.entityProvider;
+            Assert.AreEqual(BlockType.PISTON, aep.GetBlockType());
+        }
+
+        [TestMethod]
+        public void AllSelectorGroupWithCondition() {
+            var command = ParseCommand("recharge all batteries whose ratio < 0.25");
+            Assert.IsTrue(command is BlockCommand);
+            BlockCommand bc = (BlockCommand)command;
+            Assert.IsTrue(bc.entityProvider is ConditionalEntityProvider);
+            ConditionalEntityProvider cep = (ConditionalEntityProvider)bc.entityProvider;
+            Assert.IsTrue(cep.provider is AllEntityProvider);
+            AllEntityProvider aep = (AllEntityProvider)cep.provider;
+            Assert.AreEqual(BlockType.BATTERY, aep.GetBlockType());
+        }
+
+        [TestMethod]
+        public void ImplicitAllSelector() {
+            var command = ParseCommand("turn on the light");
+            Assert.IsTrue(command is BlockCommand);
+            BlockCommand bc = (BlockCommand)command;
+            Assert.IsTrue(bc.entityProvider is AllEntityProvider);
+            AllEntityProvider aep = (AllEntityProvider)bc.entityProvider;
+            Assert.AreEqual(BlockType.LIGHT, aep.GetBlockType());
+        }
+
+        [TestMethod]
+        public void ImplicitAllGroupSelector() {
+            var command = ParseCommand("turn on the lights");
+            Assert.IsTrue(command is BlockCommand);
+            BlockCommand bc = (BlockCommand)command;
+            Assert.IsTrue(bc.entityProvider is AllEntityProvider);
+            AllEntityProvider aep = (AllEntityProvider)bc.entityProvider;
+            Assert.AreEqual(BlockType.LIGHT, aep.GetBlockType());
+        }
     }
 }

--- a/EasyCommands/BlockHandlers/BlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/BlockHandlers.cs
@@ -50,9 +50,11 @@ namespace IngameScript {
                 if (!blockHandlers.ContainsKey(blockType)) throw new Exception("Unsupported Block Type: " + blockType);
                 return blockHandlers[blockType];
             }
-            public static List<Object> GetBlocks(BlockType blockType, String customName) {
-                return blockHandlers[blockType].GetBlocks(customName);
+
+            public static List<Object> GetBlocks(BlockType blockType, Func<IMyTerminalBlock, bool> selector) {
+                return blockHandlers[blockType].GetBlocks(selector);
             }
+
             public static List<Object> GetBlocksInGroup(BlockType blockType, String groupName) {
                 return blockHandlers[blockType].GetBlocksInGroup(groupName);
             }
@@ -209,7 +211,7 @@ namespace IngameScript {
             PropertyType GetDefaultProperty(PrimitiveType type);
             PropertyType GetDefaultProperty(DirectionType direction);
             DirectionType GetDefaultDirection();
-            List<Object> GetBlocks(String name);
+            List<Object> GetBlocks(Func<IMyTerminalBlock, bool> selector);
             List<Object> GetBlocksInGroup(String groupName);
 
             Primitive GetPropertyValue(Object block, PropertyType property);
@@ -238,9 +240,9 @@ namespace IngameScript {
                 defaultPropertiesByPrimitive[PrimitiveType.VECTOR] = PropertyType.POSITION;
             }
 
-            public override List<T> GetBlocksOfType(String name) {
+            public override List<T> GetBlocksOfType(Func<IMyTerminalBlock, bool> selector) {
                 List<T> blocks = new List<T>();
-                PROGRAM.GridTerminalSystem.GetBlocksOfType<T>(blocks, block => block.CustomName.Equals(name));
+                PROGRAM.GridTerminalSystem.GetBlocksOfType<T>(blocks, selector);
                 return blocks;
             }
 
@@ -278,10 +280,10 @@ namespace IngameScript {
             protected Dictionary<DirectionType, PropertyType> defaultPropertiesByDirection = new Dictionary<DirectionType, PropertyType>();
             protected DirectionType? defaultDirection = null;
 
-            public List<Object> GetBlocks(String name) { return GetBlocksOfType(name).Select(t => t as object).ToList(); }
+            public List<Object> GetBlocks(Func<IMyTerminalBlock, bool> selector) { return GetBlocksOfType(selector).Select(t => t as object).ToList(); }
             public List<Object> GetBlocksInGroup(String groupName) { return GetBlocksOfTypeInGroup(groupName).Select(t => t as object).ToList(); }
 
-            public abstract List<T> GetBlocksOfType(String name);
+            public abstract List<T> GetBlocksOfType(Func<IMyTerminalBlock, bool> selector);
             public abstract List<T> GetBlocksOfTypeInGroup(String name);
 
             public DirectionType GetDefaultDirection() {

--- a/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
+++ b/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
@@ -30,9 +30,9 @@ namespace IngameScript {
                 defaultDirection = DirectionType.UP;
             }
 
-            public override List<IMyTextSurface> GetBlocksOfType(String name) {
+            public override List<IMyTextSurface> GetBlocksOfType(Func<IMyTerminalBlock, bool> selector) {
                 List<IMyTerminalBlock> blocks = new List<IMyTerminalBlock>();
-                PROGRAM.GridTerminalSystem.GetBlocksOfType(blocks, block => block.CustomName.Equals(name));
+                PROGRAM.GridTerminalSystem.GetBlocksOfType(blocks, selector);
 
                 List<IMyTextSurface> surfaces = new List<IMyTextSurface>();
                 blocks.ForEach((b)=>Add(b, surfaces));

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -68,7 +68,7 @@ namespace IngameScript {
         static String[] greaterWords = { "greater", ">", "above", "more" };
 
         static String[] anyWords = { "any" };
-        static String[] allWords = { "all" };
+        static String[] allWords = { "all", "every", "each" };
         static String[] noneWords = { "none" };
 
         static String[] andWords = { "and", "&", "&&", "but", "yet" };

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -170,13 +170,30 @@ namespace IngameScript {
                         return new VariableCommandParameter(new AggregatePropertyVariable(p.Value, selector.GetValue().Value, property, direction));
                     }),
 
-                //AggregationProcessor
+                //AggregateConditionProcessors
                 TwoValueRule<BlockConditionCommandParameter,AggregationModeCommandParameter,SelectorCommandParameter>(
                     optionalLeft<AggregationModeCommandParameter>(),requiredLeft<SelectorCommandParameter>(),
                     (p,aggregation,selector) => {
                         AggregationMode mode = aggregation.HasValue() ? aggregation.GetValue().Value : AggregationMode.ALL;
                         return new VariableCommandParameter(new AggregateConditionVariable(mode, p.Value, selector.GetValue().Value));
                     }),
+                TwoValueRule<BlockConditionCommandParameter,AggregationModeCommandParameter,BlockTypeCommandParameter>(
+                    optionalLeft<AggregationModeCommandParameter>(),requiredLeft<BlockTypeCommandParameter>(),
+                    (p,aggregation,blockType) => {
+                        AggregationMode mode = aggregation.HasValue() ? aggregation.GetValue().Value : AggregationMode.ALL;
+                        return new VariableCommandParameter(new AggregateConditionVariable(mode, p.Value, new AllEntityProvider(blockType.GetValue().Value)));
+                    }),
+
+                //ImplicitAllSelectorProcessor
+                OneValueRule<BlockTypeCommandParameter,GroupCommandParameter>(
+                    optionalRight<GroupCommandParameter>(),
+                    (blockType, group) => new SelectorCommandParameter(new AllEntityProvider(blockType.Value))),
+
+                //AggregateSelectorProcessor
+                OneValueRule<AggregationModeCommandParameter,SelectorCommandParameter>(
+                    requiredRight<SelectorCommandParameter>(),
+                    (aggregation, selector) => aggregation.Value != AggregationMode.NONE && selector.HasValue(),
+                    (aggregation, selector) => selector.GetValue()),
 
                 //IteratorProcessor
                 OneValueRule<IteratorCommandParameter,VariableCommandParameter>(

--- a/EasyCommands/Commands/EntityProviders.cs
+++ b/EasyCommands/Commands/EntityProviders.cs
@@ -80,7 +80,7 @@ namespace IngameScript {
 
             public List<Object> GetEntities() {
                 String selectorString = CastString(selector.GetValue()).GetStringValue();
-                List<object> entities = isGroup ? BlockHandlerRegistry.GetBlocksInGroup(blockType, selectorString) : BlockHandlerRegistry.GetBlocks(blockType, selectorString);
+                List<object> entities = isGroup ? BlockHandlerRegistry.GetBlocksInGroup(blockType, selectorString) : BlockHandlerRegistry.GetBlocks(blockType, block => block.CustomName.Equals(selectorString));
                 return entities;
             }
 
@@ -106,6 +106,22 @@ namespace IngameScript {
 
             public List<object> GetEntities() {
                 return BlockHandlerRegistry.GetBlocksInGroup(blockType, PROGRAM.Me.CustomName);
+            }
+        }
+
+        public class AllEntityProvider : EntityProvider {
+            public BlockType blockType;
+
+            public AllEntityProvider(BlockType blockType) {
+                this.blockType = blockType;
+            }
+
+            public BlockType GetBlockType() {
+                return blockType;
+            }
+
+            public List<object> GetEntities() {
+                return BlockHandlerRegistry.GetBlocks(blockType, block => true);
             }
         }
     }


### PR DESCRIPTION
This change allows you to perform an action on all blocks of a given type without defining a group.

The new selectors can be used in block commands to perform actions, or in aggregate block conditions to check for block state.

You can also use this to get aggregate block properties.

I messed up the last pull request #43 , resubmitting