### PR TITLE
Added TextSurface and Subclass Mocking Support

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -136,6 +136,8 @@
     <Compile Include="ScriptTests\RotorBlockTests.cs" />
     <Compile Include="ScriptTests\CameraBlockTests.cs" />
     <Compile Include="ScriptTests\SensorBlockTests.cs" />
+    <Compile Include="ScriptTests\TextSurfaceBlockTests.cs" />
+    <Compile Include="ScriptTests\SubclassBlockTests.cs" />
     <Compile Include="TokenParsingTests\StringParsingTests.cs" />
     <Compile Include="TokenParsingTests\ParenthesisParsingTests.cs" />
     <Compile Include="Util\Extensions.cs" />

--- a/EasyCommands.Tests/ScriptTests/MockEntityUtility.cs
+++ b/EasyCommands.Tests/ScriptTests/MockEntityUtility.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Moq;
 using System.Threading.Tasks;
 using Sandbox.ModAPI.Ingame;
 using VRageMath;
@@ -16,6 +17,13 @@ namespace EasyCommands.Tests.ScriptTests {
 
         public static MyDetectedEntityInfo MockNoDetectedEntity() {
             return new MyDetectedEntityInfo();
+        }
+
+        public static void MockTextSurfaces<T>(Mock<T> surfaceProvider, params Mock<IMyTextSurface>[] mockSurfaces) where T : class, IMyTextSurfaceProvider {
+            surfaceProvider.Setup(x => x.SurfaceCount).Returns(mockSurfaces.Length);
+            for(int i = 0; i < mockSurfaces.Length; i++) {
+                surfaceProvider.Setup(x => x.GetSurface(i)).Returns(mockSurfaces[i].Object);
+            }
         }
     }
 }

--- a/EasyCommands.Tests/ScriptTests/SubclassBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SubclassBlockTests.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+using VRageMath;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class SubclassBlockTests {
+
+        //Performs some basic tests to confirm we can retrieve classes using their blockhandler's parent class.
+        [TestMethod]
+        public void MissileLauncherIsAGun() {
+            String script = @"
+power on the ""test missile"" gun 
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockMissileLauncher = new Mock<IMySmallMissileLauncher>();
+                test.MockBlocksOfType("test missile", mockMissileLauncher);
+
+                test.RunUntilDone();
+
+                mockMissileLauncher.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void CockpitIsAShipController() {
+            String script = @"
+lock the ""test cockpit""
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockCockpit = new Mock<IMyCockpit>();
+                test.MockBlocksOfType("test cockpit", mockCockpit);
+
+                test.RunUntilDone();
+
+                mockCockpit.VerifySet(b => b.HandBrake = true);
+            }
+        }
+    }
+}

--- a/EasyCommands.Tests/ScriptTests/TextSurfaceBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/TextSurfaceBlockTests.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+using VRageMath;
+using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class TextSurfaceBlockTests {
+        [TestMethod]
+        public void SetTextPanelText() {
+            String script = @"
+set the ""text panel"" display text to ""Hello World""
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockTextPanel = new Mock<IMyTextPanel>();
+                test.MockBlocksOfType("text panel", mockTextPanel);
+
+                test.RunUntilDone();
+
+                mockTextPanel.Verify(b => b.WriteText("Hello World", false));
+            }
+        }
+
+        [TestMethod]
+        public void SetProgrammableBlockDisplayText() {
+            String script = @"
+set the ""test program"" display @ 0 text to ""Hello World""
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockProgram = new Mock<IMyProgrammableBlock>();
+                var mockDisplay = new Mock<IMyTextSurface>();
+
+                MockTextSurfaces(mockProgram, mockDisplay);
+
+                test.MockBlocksOfType("test program", mockProgram);
+
+                test.RunUntilDone();
+
+                mockDisplay.Verify(b => b.WriteText("Hello World", false));
+            }
+        }
+
+        [TestMethod]
+        public void SetProgrammableBlockKeyboardText() {
+            String script = @"
+set the ""test program"" display @ 1 text to ""Hello World""
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockProgram = new Mock<IMyProgrammableBlock>();
+                var mockDisplay = new Mock<IMyTextSurface>();
+                var mockKeyboard = new Mock<IMyTextSurface>();
+
+                MockTextSurfaces(mockProgram, mockDisplay, mockKeyboard);
+
+                test.MockBlocksOfType("test program", mockProgram);
+
+                test.RunUntilDone();
+
+                mockKeyboard.Verify(b => b.WriteText("Hello World", false));
+            }
+        }
+
+        [TestMethod]
+        public void SetCockpitDisplayText() {
+            String script = @"
+set the ""test cockpit"" display @ 0 text to ""Hello World""
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockCockpit = new Mock<IMyCockpit>();
+                var mockDisplay = new Mock<IMyTextSurface>();
+
+                MockTextSurfaces(mockCockpit, mockDisplay);
+
+                test.MockBlocksOfType("test cockpit", mockCockpit);
+
+                test.RunUntilDone();
+
+                mockDisplay.Verify(b => b.WriteText("Hello World", false));
+            }
+        }
+
+        [TestMethod]
+        public void SetCockpitKeyboardText() {
+            String script = @"
+set the ""test cockpit"" display @ 1 text to ""Hello World""
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockCockpit = new Mock<IMyCockpit>();
+                var mockDisplay = new Mock<IMyTextSurface>();
+                var mockKeyboard = new Mock<IMyTextSurface>();
+
+                MockTextSurfaces(mockCockpit, mockDisplay, mockKeyboard);
+
+                test.MockBlocksOfType("test cockpit", mockCockpit);
+
+                test.RunUntilDone();
+
+                mockKeyboard.Verify(b => b.WriteText("Hello World", false));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit adds support for mocking text surfaces on text surface providers.  It also adds tests confirming we can now test textsurfaces.

Additionally, this commit replaces our mock block grid and mock block groups with a proper implementation to overcome the issues with subclass casting which the
moq framework can't really deal with.

This commit resolves #46 