### PR TITLE
This commit adds the ability to process multiple possible parsings fo…

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
@@ -106,5 +106,54 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.IsTrue(aggregate.entityProvider is AllEntityProvider);
             Assert.AreEqual(BlockType.GUN, aggregate.entityProvider.GetBlockType());
         }
+
+        [TestMethod]
+        public void AssignAvgOfBlocksUsingImplicitAggregate() {
+            var command = ParseCommand("assign \"a\" to the \"test gun\" range");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
+            AggregatePropertyVariable aggregate = (AggregatePropertyVariable)assignCommand.variable;
+            Assert.AreEqual(PropertyAggregatorType.VALUE, aggregate.aggregationType);
+            Assert.IsTrue(aggregate.entityProvider is SelectorEntityProvider);
+            Assert.AreEqual(BlockType.GUN, aggregate.entityProvider.GetBlockType());
+        }
+
+        [TestMethod]
+        public void AssignAvgOfBlocksUsingImplicitAggregateInParentheses() {
+            var command = ParseCommand("assign \"a\" to the ( \"test gun\" range )" );
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
+            AggregatePropertyVariable aggregate = (AggregatePropertyVariable)assignCommand.variable;
+            Assert.AreEqual(PropertyAggregatorType.VALUE, aggregate.aggregationType);
+            Assert.IsTrue(aggregate.entityProvider is SelectorEntityProvider);
+            Assert.AreEqual(BlockType.GUN, aggregate.entityProvider.GetBlockType());
+        }
+
+        [TestMethod]
+        public void AssignAvgOfBlocksUsingImplicitAggregateAndImplicitSelector() {
+            var command = ParseCommand("assign \"a\" to the gun range");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
+            AggregatePropertyVariable aggregate = (AggregatePropertyVariable)assignCommand.variable;
+            Assert.AreEqual(PropertyAggregatorType.VALUE, aggregate.aggregationType);
+            Assert.IsTrue(aggregate.entityProvider is AllEntityProvider);
+            Assert.AreEqual(BlockType.GUN, aggregate.entityProvider.GetBlockType());
+        }
+
+        [TestMethod]
+        public void AssignAvgOfBlocksUsingImplicitAggregateAndMySelector() {
+            var command = ParseCommand("assign \"a\" to my location");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
+            AggregatePropertyVariable aggregate = (AggregatePropertyVariable)assignCommand.variable;
+            Assert.AreEqual(PropertyAggregatorType.VALUE, aggregate.aggregationType);
+            Assert.AreEqual(PropertyType.POSITION, aggregate.property);
+            Assert.IsTrue(aggregate.entityProvider is SelfEntityProvider);
+            Assert.AreEqual(BlockType.PROGRAM, aggregate.entityProvider.GetBlockType());
+        }
     }
 }

--- a/EasyCommands.Tests/ScriptTests/CameraBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/CameraBlockTests.cs
@@ -11,7 +11,7 @@ namespace EasyCommands.Tests.ScriptTests {
         [TestMethod]
         public void getCameraRange() {
             String script = @"
-assign ""a"" to avg ""mock camera"" range
+assign ""a"" to ""mock camera"" range
 print ""Range: "" + {a}
 ";
             using (var test = new ScriptTest(script)) {
@@ -61,7 +61,7 @@ trigger the ""mock camera""
         public void cameraIsTriggeredGetTarget() {
             String script = @"
 when ""mock camera"" is triggered
-  print ""Target: "" + avg ""mock camera"" target
+  print ""Target: "" + ""mock camera"" target
 ";
             using (var test = new ScriptTest(script)) {
                 var mockCamera = new Mock<IMyCameraBlock>();
@@ -94,7 +94,7 @@ when ""mock camera"" is triggered
         [TestMethod]
         public void LastTargetIsStillAvailableWhenCannotScan() {
             String script = @"
-print ""Target: "" + avg ""mock camera"" target
+print ""Target: "" + ""mock camera"" target
 ";
             using (var test = new ScriptTest(script)) {
                 var mockCamera = new Mock<IMyCameraBlock>();
@@ -114,7 +114,7 @@ print ""Target: "" + avg ""mock camera"" target
         [TestMethod]
         public void NoTargetReturnsZeroVector() {
             String script = @"
-print ""Target: "" + avg ""mock camera"" target
+print ""Target: "" + ""mock camera"" target
 ";
             using (var test = new ScriptTest(script)) {
                 var mockCamera = new Mock<IMyCameraBlock>();

--- a/EasyCommands.Tests/ScriptTests/SensorBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SensorBlockTests.cs
@@ -11,7 +11,7 @@ namespace EasyCommands.Tests.ScriptTests {
         [TestMethod]
         public void SensorTargetReturnsZeroVectorWhenNothingDetected() {
             String script = @"
-print ""Target: "" + avg ""mock sensor"" target
+print ""Target: "" + ""mock sensor"" target
 ";
             using (var test = new ScriptTest(script)) {
                 var mockSensor = new Mock<IMySensorBlock>();
@@ -30,7 +30,7 @@ print ""Target: "" + avg ""mock sensor"" target
         public void TriggerTheSensorAndGetTarget() {
             String script = @"
 when ""mock sensor"" is triggered
-  print ""Target: "" + avg ""mock sensor"" target
+  print ""Target: "" + ""mock sensor"" target
 ";
             using (var test = new ScriptTest(script)) {
                 var mockSensor = new Mock<IMySensorBlock>();

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -327,7 +327,7 @@ namespace IngameScript {
             /// This method inline processes the given list of command parameters.
             /// Any ambiguous parsing branches which were found during processing are also returned as additional entries.
             /// If the desired result (typically a command) does not result from the returned parse, the returned
-            /// branches can be re-processed to see if a correct parse results from the altneratve branch.
+            /// branches can be re-processed to see if a correct parse results from the alternate branches.
             /// This can continue until no alternate branches are returned.
             /// </summary>
             /// <param name="commandParameters"></param>

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -206,9 +206,21 @@ namespace IngameScript {
                     (p,var) => new ConditionCommandParameter(p.inverseCondition ? new UniOperandVariable(UniOperandType.NOT, var.GetValue().Value) : var.GetValue().Value, p.alwaysEvaluate, p.swapCommands)),
 
                 //ActionProcessor
-                //TODO I'll be back for you
-                //new ActionProcessor(),
                 BlockCommandProcessor(),
+
+                //AmgiguousSelectorPropertyProcessor
+                new BranchingProcessor<SelectorCommandParameter>(
+                    TwoValueRule<SelectorCommandParameter,PropertyCommandParameter,DirectionCommandParameter>(
+                        optionalEither<PropertyCommandParameter>(), optionalEither<DirectionCommandParameter>(),
+                        (s,p,d) => new VariableCommandParameter(new AggregatePropertyVariable(PropertyAggregatorType.VALUE, s.Value, p.HasValue() ? p.GetValue().Value : (PropertyType?)null, d.HasValue() ? d.GetValue().Value : (DirectionType?)null))),
+                    TwoValueRule<SelectorCommandParameter,PropertyCommandParameter,DirectionCommandParameter>(
+                        optionalEither<PropertyCommandParameter>(), optionalEither<DirectionCommandParameter>(),
+                        (s,p,d) => {
+                            List<CommandParameter> blockParameters = new List<CommandParameter>{s};
+                            if(p.HasValue()) blockParameters.Add(p.GetValue());
+                            if(d.HasValue()) blockParameters.Add(d.GetValue());
+                            return new CommandReferenceParameter(new BlockCommand(blockParameters));
+                        })),
 
                 //PrintCommandProcessor
                 OneValueRule<PrintCommandParameter,VariableCommandParameter>(
@@ -311,11 +323,21 @@ namespace IngameScript {
                 }
             }
 
-            public static void Process(List<CommandParameter> commandParameters) {
+            /// <summary>
+            /// This method inline processes the given list of command parameters.
+            /// Any ambiguous parsing branches which were found during processing are also returned as additional entries.
+            /// If the desired result (typically a command) does not result from the returned parse, the returned
+            /// branches can be re-processed to see if a correct parse results from the altneratve branch.
+            /// This can continue until no alternate branches are returned.
+            /// </summary>
+            /// <param name="commandParameters"></param>
+            /// <returns></returns>
+            public static List<List<CommandParameter>> Process(List<CommandParameter> commandParameters) {
                 InitializeProcessors();
 
                 List<ParameterProcessor> sortedParameterProcessors = new List<ParameterProcessor>();
 
+                List<List<CommandParameter>> branches = new List<List<CommandParameter>>();
                 AddProcessors(commandParameters, sortedParameterProcessors);
 
                 int processorIndex = 0;
@@ -327,7 +349,7 @@ namespace IngameScript {
                     for (int i = 0; i < commandParameters.Count; i++) {
                         if (current.CanProcess(commandParameters[i])) {
                             List<CommandParameter> finalParameters;
-                            if (current.Process(commandParameters, i, out finalParameters)) {
+                            if (current.Process(commandParameters, i, out finalParameters, branches)) {
                                 AddProcessors(finalParameters, sortedParameterProcessors);
                                 processed = true;
                                 //break; TODO: -Not sure if this may be needed! But much faster processing w/o this.
@@ -338,6 +360,8 @@ namespace IngameScript {
                     if (!revisit) sortedParameterProcessors.RemoveAt(processorIndex);
                     else processorIndex++;
                 }
+
+                return branches;
             }
 
             static void AddProcessors(List<CommandParameter> types, List<ParameterProcessor> sortedParameterProcessors) {
@@ -474,7 +498,7 @@ namespace IngameScript {
             int Rank { get; set; }
             List<Type> GetProcessedTypes();
             bool CanProcess(CommandParameter p); 
-            bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters);
+            bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters, List<List<CommandParameter>> branches);
         }
 
         public abstract class ParameterProcessor<T> : ParameterProcessor where T : class, CommandParameter {
@@ -482,18 +506,25 @@ namespace IngameScript {
             public virtual List<Type> GetProcessedTypes() { return new List<Type>() { typeof(T) }; }
             public int CompareTo(ParameterProcessor other) => Rank.CompareTo(other.Rank);
             public bool CanProcess(CommandParameter p) => p is T;
-            public abstract bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters);
+            public abstract bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters, List<List<CommandParameter>> branches);
         }
 
         public class ParenthesisProcessor : ParameterProcessor<OpenParenthesisCommandParameter> {
-            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters) {
+            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters, List<List<CommandParameter>> branches) {
                 finalParameters = null;
                 for(int j = i + 1; j < p.Count; j++) {
                     if (p[j] is OpenParenthesisCommandParameter) return false;
                     else if (p[j] is CloseParenthesisCommandParameter) {
                         finalParameters = p.GetRange(i+1, j - (i+1));
-                        ParameterProcessorRegistry.Process(finalParameters);
+                        var alternateBranches = ParameterProcessorRegistry.Process(finalParameters);
                         p.RemoveRange(i, j - i + 1);
+
+                        for (int k = 0; k < alternateBranches.Count; k++) {
+                            var copy = new List<CommandParameter>(p);
+                            copy.InsertRange(i, alternateBranches[k]);
+                            branches.Add(copy);
+                        }
+
                         p.InsertRange(i, finalParameters);
                         return true;
                     }
@@ -507,7 +538,7 @@ namespace IngameScript {
                 return new List<Type>() { typeof(StringCommandParameter), typeof(NumericCommandParameter), typeof(BooleanCommandParameter), typeof(ExplicitStringCommandParameter) };
             }
 
-            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters) {
+            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters, List<List<CommandParameter>> branches) {
                 if (p[i] is ValueCommandParameter<String>) {
                     p[i] = GetParameter(((ValueCommandParameter<String>)p[i]).Value);
                 } else if (p[i] is NumericCommandParameter) {
@@ -532,6 +563,34 @@ namespace IngameScript {
             }
         }
 
+        class BranchingProcessor<T> : ParameterProcessor<T> where T : class, CommandParameter {
+            List<ParameterProcessor<T>> processors;
+
+            public BranchingProcessor(params ParameterProcessor<T>[] p) {
+                processors = new List<ParameterProcessor<T>>(p);
+            }
+
+            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters, List<List<CommandParameter>> branches) {
+                finalParameters = null;
+                var eligibleProcessors = processors.Where(processor => processor.CanProcess(p[i])).ToList();
+                var copy = new List<CommandParameter>(p);
+
+                bool processed = false;
+                foreach(ParameterProcessor processor in eligibleProcessors) { 
+                    if (processed) {
+                        List<CommandParameter> ignored;
+                        var additionalCopy = new List<CommandParameter>(copy);
+                        if (processor.Process(additionalCopy, i, out ignored, branches)) {
+                            branches.Insert(0, additionalCopy);
+                        }
+                    } else {
+                        processed = processor.Process(p, i, out finalParameters, branches);
+                    }
+                }
+                return processed;
+            }
+        }
+
         class RuleProcessor<T> : ParameterProcessor<T> where T : class, CommandParameter {
             List<DataProcessor> processors;
             CanConvert<T> canConvert;
@@ -543,7 +602,7 @@ namespace IngameScript {
                 this.convert = convert;
             }
 
-            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters) {
+            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters, List<List<CommandParameter>> branches) {
                 finalParameters = null;
                 processors.ForEach(dp => dp.fetcher.Clear());
                 int j = i + 1;
@@ -616,7 +675,7 @@ namespace IngameScript {
                 reverseProcessor
             };
 
-            CanConvert<SelectorCommandParameter> canConvert = (p) => processors.Exists(x => x.fetcher.Satisfied() && x != actionProcessor && x != relativeProcessor);
+            CanConvert<SelectorCommandParameter> canConvert = (p) => processors.Exists(x => x.fetcher.Satisfied() && x != directionProcessor && x != propertyProcessor);
             //TODO: Get rid of block handlers altogether
             Convert<SelectorCommandParameter> convert = (p) => {
                 List<CommandParameter> commandParameters = new List<CommandParameter> { p };

--- a/EasyCommands/Common/Aggregators.cs
+++ b/EasyCommands/Common/Aggregators.cs
@@ -19,6 +19,13 @@ using VRageMath;
 
 namespace IngameScript {
     partial class Program {
+        public static Primitive ValueAggregator(List<Primitive> primitives) {
+            if (primitives.Count != 1) {
+                throw new Exception("Exact Value Aggregate must reference a selector with exactly one value");
+            }
+            return primitives[0];
+        }
+
         public static Primitive SumAggregator(List<Primitive> primitives) {
             if (primitives.Count==0) {
                 throw new Exception("Cannot sum an empty list");

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -32,7 +32,7 @@ namespace IngameScript {
         public enum BiOperandType { ADD, SUBTACT, MULTIPLY, DIVIDE, MOD, AND, OR, COMPARE };
         public enum UniOperandType { NOT, ABS, SQRT };
         public enum LogLevel { TRACE, DEBUG, INFO, SCRIPT_ONLY }
-        public enum PropertyAggregatorType { SUM, COUNT, AVG, MIN, MAX };
+        public enum PropertyAggregatorType { VALUE, SUM, COUNT, AVG, MIN, MAX };
         #endregion
     }
 }

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -155,6 +155,8 @@ namespace IngameScript {
                 }).ToList();
 
                 switch(aggregationType) {
+                    case PropertyAggregatorType.VALUE:
+                        return ValueAggregator(propertyValues);
                     case PropertyAggregatorType.SUM:
                         return SumAggregator(propertyValues);
                     case PropertyAggregatorType.AVG:

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -298,10 +298,20 @@ namespace IngameScript {
             Trace("Pre Processed Parameters:");
             parameters.ForEach(param => Trace("Type: " + param.GetType()));
 
-            ParameterProcessorRegistry.Process(parameters);
+            var branches = new List<List<CommandParameter>>();
+            branches.Add(parameters);
 
-            if (parameters.Count != 1 || !(parameters[0] is CommandReferenceParameter)) throw new Exception("Unable to parse command from command parameters!");
-            return ((CommandReferenceParameter)parameters[0]).Value;
+            //Branches
+            while (branches.Count > 0) {
+                branches.AddRange(ParameterProcessorRegistry.Process(branches[0]));
+                if (branches[0].Count == 1 && branches[0][0] is CommandReferenceParameter) {
+                    return ((CommandReferenceParameter)branches[0][0]).Value;
+                } else {
+                    branches.RemoveAt(0);
+                }
+            }
+
+            throw new Exception("Unable to parse command from command parameters!");
         }
 
         class CommandLine {


### PR DESCRIPTION
This commit adds the ability to process multiple possible parsings for ambiguous requests such as selector + property, where it could either be an aggregate variable or a block command depending on the context.

It then adds a new branch processor for block + property + direction in isolation which default parses as an implicit block aggregate property, with the fallback branch being a stand alone block command.

Implicit Aggregate Property uses a new AggregationMode for "value".  This aggregation mode throws an exception if the input selector has more than 1 value.  The
result is that you will get an exception during execution if you try to use an implicit aggregation on a selector property that contains more than one block.

Also adds test and modifies some of the existing script tests to confirm the new parsing is working.


I also verified the changes by updating my "follow me" ship locally and it works!

This commit resolves #32 




