### PR TITLE
Added Implicit Variable Selector Block Type Support

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
@@ -76,6 +76,18 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         }
 
         [TestMethod]
+        public void ImplicitVariableSelector() {
+            var command = ParseCommand("turn on the [a]");
+            Assert.IsTrue(command is BlockCommand);
+            BlockCommand bc = (BlockCommand)command;
+            Assert.IsTrue(bc.entityProvider is SelectorEntityProvider);
+            SelectorEntityProvider sep = (SelectorEntityProvider)bc.entityProvider;
+            Assert.IsTrue(sep.selector is InMemoryVariable);
+            InMemoryVariable variable = (InMemoryVariable)sep.selector;
+            Assert.AreEqual("a", variable.variableName);
+        }
+
+        [TestMethod]
         public void MySelector() {
             var command = ParseCommand("assign a to my average location");
             Assert.IsTrue(command is VariableAssignmentCommand);

--- a/EasyCommands.Tests/ScriptTests/SimpleBlockCommandTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleBlockCommandTests.cs
@@ -115,5 +115,46 @@ turn on the ""hangar lights""
                 mockOtherLight.VerifySet(b => b.Intensity = 10f, Times.Never);
             }
         }
+
+        [TestMethod]
+        public void UseVariableAsImplicitBlockSelector() {
+            String script = @"
+assign ""myLights"" to 'test lights'
+turn on [myLights]
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockLight = new Mock<IMyLightingBlock>();
+                test.MockBlocksInGroup("test lights", mockLight);
+
+                test.RunUntilDone();
+
+                mockLight.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void UseVariableAsImplicitBlockSelectorInConditionAndBlockCommand() {
+            String script = @"
+assign ""myLights"" to 'test lights'
+if [myLights] are on
+  Print 'You Left The Lights On'
+  turn off [myLights]
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockLight = new Mock<IMyLightingBlock>();
+                test.MockBlocksInGroup("test lights", mockLight);
+                mockLight.Setup(b => b.Enabled).Returns(true);
+
+                test.RunUntilDone();
+
+                mockLight.VerifySet(b => b.Enabled = false);
+
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("You Left The Lights On", test.Logger[0]);
+            }
+        }
+
     }
 }

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -71,8 +71,8 @@ namespace IngameScript {
 
                 //VariableSelectorProcessor
                 TwoValueRule<VariableSelectorCommandParameter,BlockTypeCommandParameter,GroupCommandParameter>(
-                    requiredRight<BlockTypeCommandParameter>(),optionalRight<GroupCommandParameter>(),
-                    (p,blockType,group) => new SelectorCommandParameter(new SelectorEntityProvider(blockType.GetValue().Value, group.HasValue(), p.Value))),
+                    optionalRight<BlockTypeCommandParameter>(),optionalRight<GroupCommandParameter>(),
+                    (p,blockType,group) => new SelectorCommandParameter(new SelectorEntityProvider(blockType.HasValue() ? blockType.GetValue().Value : (BlockType?)null, group.HasValue(), p.Value))),
 
                 //Primitive Procesor
                 new PrimitiveProcessor(),

--- a/EasyCommands/Commands/Commands.cs
+++ b/EasyCommands/Commands/Commands.cs
@@ -227,12 +227,10 @@ namespace IngameScript {
         public class NullCommand : Command { public override bool Execute() { return true; } }
 
         public class BlockCommand : Command {
-            public BlockHandler blockHandler;
             public EntityProvider entityProvider;
             public BlockCommandHandler commandHandler;
 
-            public BlockCommand(BlockHandler blockHandler, EntityProvider entityProvider, BlockCommandHandler commandHandler) {
-                this.blockHandler = blockHandler;
+            public BlockCommand(EntityProvider entityProvider, BlockCommandHandler commandHandler) {
                 this.entityProvider = entityProvider;
                 this.commandHandler = commandHandler;
             }
@@ -255,8 +253,7 @@ namespace IngameScript {
             }
 
             public override bool Execute() {
-                blockHandler = BlockHandlerRegistry.GetBlockHandler(entityProvider.GetBlockType());
-                commandHandler.b = blockHandler;
+                commandHandler.b = BlockHandlerRegistry.GetBlockHandler(entityProvider.GetBlockType());
                 commandHandler.Execute();
                 return true;
             }
@@ -312,7 +309,7 @@ namespace IngameScript {
                         b.ReverseNumericPropertyValue(e, property); }),
                 };
             }
-            public override Command Clone() { return new BlockCommand(blockHandler, entityProvider, commandHandler); }
+            public override Command Clone() { return new BlockCommand(entityProvider, commandHandler); }
         }
 
         public class ConditionalCommand : Command {

--- a/EasyCommands/Commands/Commands.cs
+++ b/EasyCommands/Commands/Commands.cs
@@ -245,7 +245,6 @@ namespace IngameScript {
                 foreach (BlockCommandHandler handler in GetHandlers()) {
                     if (handler.canHandle(parameters)) {
                         commandHandler = handler;
-                        commandHandler.b = blockHandler;
                         commandHandler.e = entityProvider;
                         return;
                     }
@@ -256,6 +255,8 @@ namespace IngameScript {
             }
 
             public override bool Execute() {
+                blockHandler = BlockHandlerRegistry.GetBlockHandler(entityProvider.GetBlockType());
+                commandHandler.b = blockHandler;
                 commandHandler.Execute();
                 return true;
             }
@@ -264,7 +265,6 @@ namespace IngameScript {
                 extract<ActionCommandParameter>(commandParameters);//Extract and ignore
                 SelectorCommandParameter selector = extractFirst<SelectorCommandParameter>(commandParameters);
                 if (selector == null) throw new Exception("SelectorCommandParameter is required for command: " + GetType());
-                blockHandler = BlockHandlerRegistry.GetBlockHandler(selector.Value.GetBlockType());
                 entityProvider = selector.Value;
             }
 


### PR DESCRIPTION
This commit makes blockType in SelectorEntityProvider an optional field, and adds just in time blockType & group resolution if blockType is not present.

This also involved making some changes to BlockCommand, which was pre-parsing blockType during compilation.

Additionally, the processor for variableSelector has been relaxed to allow optional blockType.  The result is implicit block type resolution for variable selectors.

Lastly, this commit adds parsing and script tests showing the new implicit variable selectors can now be used in block commands and conditions.

This commit resolves #56 