### PR TITLE
Added Support for Double Quote Explicit Strings

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
@@ -95,5 +95,13 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             var command = ParseCommand("assign \"vector\" to avg \"Main Cockpit\" position");
             Assert.IsTrue(command is VariableAssignmentCommand);
         }
+
+        [TestMethod]
+        public void AssignVariableToSelectorString() {
+            var command = ParseCommand("assign \"mySelector\" to \"Main Cockpit\"");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("Main Cockpit", assignmentCommand.variable.GetValue().GetValue());
+        }
     }
 }


### PR DESCRIPTION
This commit uses the new branching support to add new parsing support for parsing double quoted strings containing block type tokens.

Before this commit, a command like assign "v" to "my piston" would fail as "my piston" is interpreted as a selector and then the command will not parse.
This commit introduced a new branch to interpret all double quoted strings as an explicit string.  The result is that the above command now parses.

This has some ramifications to Implicite Aggregate Properties, as we must distinguish between an explicit string and an implicite aggregate property in this case.
The following rules, implemented by this CR, disambiguate:

1.  If the aggregator is specified (count, sum, avg) then property is optional as there is no ambiguity.
2.  If an implicit aggregator is intended, property must be supplied, i.e. assign v to "test piston" height presumes to get the height property of "test piston"
3.  If only a string is provided without an aggregator or a property, then we do not attempt to convert to an aggregate property.  If parsing the string as a
selector leads to a successful parse (aggregate condition, etc) then great.  Otherwise the only other branch considered will be that the string must have intended to
be a literal string.

This commit adds a simple test showing the new support works (Rule 3).  The existing tests all passing is confirmation of the above rules working as intended.

This commit resolves #60 