### PR TITLE
Added support for passing variables to queued commands

### DIFF
--- a/EasyCommands.Tests/ScriptTests/MultiThreadingTests.cs
+++ b/EasyCommands.Tests/ScriptTests/MultiThreadingTests.cs
@@ -268,5 +268,27 @@ goto printVariable
                 Assert.AreEqual("Variable is: 3", test.Logger[2]);
             }
         }
+
+        [TestMethod]
+        public void asyncCommandVariablesArePassedToAsyncThread() {
+            String script = @"
+:main
+assign ""i"" to 0
+async call printLocalVariable {i}
+assign ""i"" to {i} + 1
+async call printLocalVariable {i}
+assign ""i"" to {i} + 1
+
+:printLocalVariable ""a""
+print 'Variable is: ' + {a}
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();//Execute main, add async threads which set their variable and print
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Variable is: 0", test.Logger[0]);
+                Assert.AreEqual("Variable is: 1", test.Logger[1]);
+            }
+        }
     }
 }

--- a/EasyCommands/Commands/Commands.cs
+++ b/EasyCommands/Commands/Commands.cs
@@ -46,10 +46,12 @@ namespace IngameScript {
             }
 
             public override bool Execute() {
-                if(async) {
-                    PROGRAM.QueueAsyncThread(new Thread(command, "Queued", "Unknown"));
+                Thread thread = new Thread(command, "Queued", "Unknown");
+                thread.threadVariables = new Dictionary<string, Variable>(PROGRAM.GetCurrentThread().threadVariables);
+                if (async) {
+                    PROGRAM.QueueAsyncThread(thread);
                 } else {
-                    PROGRAM.QueueThread(new Thread(command, "Queued", "Unknown"));
+                    PROGRAM.QueueThread(thread);
                 }
                 return true;
             }


### PR DESCRIPTION
This commit changes the current behavior so that all thread variables are passed to a queued/async command as they were at the time that the command was queued.
This gives the queued/async thread access to the variable state and allows you to pass in memory variables as parameters to queued/async threads.

With this change, this commit solves a couple different problems.

Problem 1: You can't use an in-memory variable as a parameter to a queued or async function because the queued thread isn't aware of the variables you had when you
called it.  So when it tries to resolve the variable..it's not there!  You can solve this by making the variable global, but this leads to problem #2.

Problem 2: Global In-Memory Variables do not honor the state they were in when a queued or async method was invoked, since all commands running on the main queued
thread (including memory variable re-assignment) happen before any async or queued command is executed.

Problem 2 still exists for global variables.  However, by passing thread variables as they were to the queued or async thrad, the thread variables state gets
persisted into that local thread.  Any additional assignments to the variable will not affect the queued thread.  The result is that a for loop or while loop with a
counter variable, where you pass the counter variable to a queued or async command, acts as you expect it to where the thread honors the state of the variable at
the time you invoked it.