### PR TITLE
Parameter processor debugging enhancement

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="ScriptTests\TextSurfaceBlockTests.cs" />
     <Compile Include="ScriptTests\SubclassBlockTests.cs" />
     <Compile Include="ScriptTests\RocketVolleyTests.cs" />
+    <Compile Include="ScriptTests\SimpleLoggingTests.cs" />
     <Compile Include="TokenParsingTests\StringParsingTests.cs" />
     <Compile Include="TokenParsingTests\ParenthesisParsingTests.cs" />
     <Compile Include="Util\Extensions.cs" />

--- a/EasyCommands.Tests/ScriptTests/SimpleLoggingTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleLoggingTests.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using IngameScript;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class SimpleLoggingTests {
+        [TestMethod]
+        public void PrintCorrectLineNumberWhenUnableToParse() {
+            String script = @"
+:main
+print 'Hello World'
+'Hello World'
+";
+            using (var test = new ScriptTest(script)) {
+                Program.LOG_LEVEL = Program.LogLevel.INFO;
+
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 3"));
+            }
+        }
+
+        [TestMethod]
+        public void PrintCorrectLineNumberWhenUnableToParseAndImpliedMain() {
+            String script = @"
+print 'Hello World'
+'Hello World'
+";
+            using (var test = new ScriptTest(script)) {
+                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 2"));
+            }
+        }
+
+        [TestMethod]
+        public void PrintCorrectLineNumberWhenUnableToParseNestedCommand() {
+            String script = @"
+if (true)
+  print 'Hello World'
+  'Hello World'
+";
+            using (var test = new ScriptTest(script)) {
+                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 3"));
+            }
+        }
+
+        [TestMethod]
+        public void PrintCorrectLineNumberWhenUnableToParseAfterNestedCommand() {
+            String script = @"
+if (true)
+  print 'Hello World'
+  wait 5
+'Hello World'
+";
+            using (var test = new ScriptTest(script)) {
+                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 4"));
+            }
+        }
+
+        [TestMethod]
+        public void PrintCorrectLineNumberWhenUnableToParseIncludesComments() {
+            String script = @"
+if (true)
+  print 'Hello World'
+  wait 5
+#This line isn't working
+'Hello World'
+";
+            using (var test = new ScriptTest(script)) {
+                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 5"));
+            }
+        }
+
+        [TestMethod]
+        public void PrintCorrectLineNumberWhenUnableToParseIncludesEmptySpace() {
+            String script = @"
+:main
+if (true)
+  print 'Hello World'
+  wait 5
+
+:broken
+#This line isn't working
+'Hello World'
+";
+            using (var test = new ScriptTest(script)) {
+                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 8"));
+            }
+        }
+
+        [TestMethod]
+        public void PrintCorrectLineNumberWhenUnableToParseInsideFunction() {
+            String script = @"
+:main
+if (true)
+  print 'Hello World'
+  wait 5
+
+:broken
+'Hello World'
+";
+            using (var test = new ScriptTest(script)) {
+                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 7"));
+            }
+        }
+    }
+}

--- a/EasyCommands.Tests/ScriptTests/SimpleLoggingTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleLoggingTests.cs
@@ -121,5 +121,26 @@ if (true)
                 Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 7"));
             }
         }
+
+        [TestMethod]
+        public void PrintParseTreeWhenDebugging() {
+            String script = @"
+print 'Total: ' + ( 2 + 5 )
+";
+            using (var test = new ScriptTest(script)) {
+                Program.LOG_LEVEL = Program.LogLevel.DEBUG;
+
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("print 'Total: ' ADD ( 2 ADD 5 )"));
+                Assert.IsTrue(test.Logger.Contains("2 ADD 5"));
+                Assert.IsTrue(test.Logger.Contains("[Variable] ADD [Variable]"));
+                Assert.IsTrue(test.Logger.Contains("[Variable]"));
+                Assert.IsTrue(test.Logger.Contains("print 'Total: ' ADD [Variable]"));
+                Assert.IsTrue(test.Logger.Contains("print [Variable] ADD [Variable]"));
+                Assert.IsTrue(test.Logger.Contains("print [Variable]"));
+                Assert.IsTrue(test.Logger.Contains("[Command]"));
+            }
+        }
     }
 }

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -31,29 +31,29 @@ namespace IngameScript {
                     requiredRight<StringCommandParameter>(),
                     (p,name) => {
                         FunctionDefinition definition;
-                        if(!FUNCTIONS.TryGetValue(name.GetValue().Value, out definition)) throw new Exception("Unknown function: " + name.GetValue().Value);
-                        return new FunctionDefinitionCommandParameter(p.Value, definition);
+                        if(!FUNCTIONS.TryGetValue(name.GetValue().value, out definition)) throw new Exception("Unknown function: " + name.GetValue().value);
+                        return new FunctionDefinitionCommandParameter(p.value, definition);
                     }),
                 OneValueRule<FunctionCommandParameter,ExplicitStringCommandParameter>(
                     requiredRight<ExplicitStringCommandParameter>(),
                     (p,name) => {
                         FunctionDefinition definition;
-                        if(!FUNCTIONS.TryGetValue(name.GetValue().Value, out definition)) throw new Exception("Unknown function: " + name.GetValue().Value);
-                        return new FunctionDefinitionCommandParameter(p.Value, definition);
+                        if(!FUNCTIONS.TryGetValue(name.GetValue().value, out definition)) throw new Exception("Unknown function: " + name.GetValue().value);
+                        return new FunctionDefinitionCommandParameter(p.value, definition);
                     }),
 
                 //AssignmentProcessor
                 TwoValueRule<AssignmentCommandParameter,GlobalCommandParameter,StringCommandParameter>(
                     optionalRight<GlobalCommandParameter>(), requiredRight<StringCommandParameter>(),
-                    (p,g,name) => new VariableAssignmentCommandParameter(name.GetValue().Value, p.useReference, g.HasValue())),
+                    (p,g,name) => new VariableAssignmentCommandParameter(name.GetValue().value, p.useReference, g.HasValue())),
                 TwoValueRule<AssignmentCommandParameter,GlobalCommandParameter,ExplicitStringCommandParameter>(
                     optionalRight<GlobalCommandParameter>(), requiredRight<ExplicitStringCommandParameter>(),
-                    (p,g,name) => new VariableAssignmentCommandParameter(name.GetValue().Value, p.useReference, g.HasValue())),
+                    (p,g,name) => new VariableAssignmentCommandParameter(name.GetValue().value, p.useReference, g.HasValue())),
 
                 //SelfSelectorProcessor
                 OneValueRule<SelfCommandParameter,BlockTypeCommandParameter>(
                     optionalRight<BlockTypeCommandParameter>(),
-                    (p, blockType) => new SelectorCommandParameter(new SelfEntityProvider(blockType.HasValue() ? blockType.GetValue().Value : BlockType.PROGRAM))),
+                    (p, blockType) => new SelectorCommandParameter(new SelfEntityProvider(blockType.HasValue() ? blockType.GetValue().value : BlockType.PROGRAM))),
 
                 //SelectorProcessor
                 new BranchingProcessor<StringCommandParameter>(
@@ -68,13 +68,13 @@ namespace IngameScript {
                             }
                             return blockType.HasValue();
                           },
-                          (p,blockType,group) => new SelectorCommandParameter(new SelectorEntityProvider(blockType.GetValue().Value, group.HasValue(), new StaticVariable(new StringPrimitive(p.Value))))),
-                    NoValueRule<StringCommandParameter>(p => new ExplicitStringCommandParameter(p.Value))),
+                          (p,blockType,group) => new SelectorCommandParameter(new SelectorEntityProvider(blockType.GetValue().value, group.HasValue(), new StaticVariable(new StringPrimitive(p.value))))),
+                    NoValueRule<StringCommandParameter>(p => new ExplicitStringCommandParameter(p.value))),
 
                 //VariableSelectorProcessor
                 TwoValueRule<VariableSelectorCommandParameter,BlockTypeCommandParameter,GroupCommandParameter>(
                     optionalRight<BlockTypeCommandParameter>(),optionalRight<GroupCommandParameter>(),
-                    (p,blockType,group) => new SelectorCommandParameter(new SelectorEntityProvider(blockType.HasValue() ? blockType.GetValue().Value : (BlockType?)null, group.HasValue(), p.Value))),
+                    (p,blockType,group) => new SelectorCommandParameter(new SelectorEntityProvider(blockType.HasValue() ? blockType.GetValue().value : (BlockType?)null, group.HasValue(), p.value))),
 
                 //Primitive Procesor
                 new PrimitiveProcessor(),
@@ -86,79 +86,79 @@ namespace IngameScript {
                 // "not greater than" => <
                 OneValueRule<ComparisonCommandParameter,NotCommandParameter>(
                     requiredEither<NotCommandParameter>(),
-                    (p,left) => new ComparisonCommandParameter(Inverse(p.Value))),
+                    (p,left) => new ComparisonCommandParameter(Inverse(p.value))),
                 OneValueRule<ComparisonCommandParameter,ComparisonCommandParameter>(
                     requiredRight<ComparisonCommandParameter>(),
-                    (p,right) => new ComparisonCommandParameter(right.GetValue().Value)),
+                    (p,right) => new ComparisonCommandParameter(right.GetValue().value)),
 
                 //UniOperationProcessor
                 OneValueRule<UniOperationCommandParameter,VariableCommandParameter>(
                     requiredRight<VariableCommandParameter>(),
-                    (p,df) => new VariableCommandParameter(new UniOperandVariable(p.Value, df.GetValue().Value))),
+                    (p,df) => new VariableCommandParameter(new UniOperandVariable(p.value, df.GetValue().value))),
 
                 //MultiplyProcessor
                 TwoValueRule<MultiplyCommandParameter,VariableCommandParameter,VariableCommandParameter>(
                     requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
-                    (p,a,b) => new VariableCommandParameter(new BiOperandVariable(p.Value, a.GetValue().Value, b.GetValue().Value))),
+                    (p,a,b) => new VariableCommandParameter(new BiOperandVariable(p.value, a.GetValue().value, b.GetValue().value))),
 
                 //AddProcessor
                 TwoValueRule<AddCommandParameter,VariableCommandParameter,VariableCommandParameter>(
                     requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
-                    (p,a,b) => new VariableCommandParameter(new BiOperandVariable(p.Value, a.GetValue().Value, b.GetValue().Value))),
+                    (p,a,b) => new VariableCommandParameter(new BiOperandVariable(p.value, a.GetValue().value, b.GetValue().value))),
 
                 //AndProcessor
                 TwoValueRule<AndCommandParameter,VariableCommandParameter,VariableCommandParameter>(
                     requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
-                    (p,left,right) => new VariableCommandParameter(new BiOperandVariable(BiOperandType.AND, left.GetValue().Value, right.GetValue().Value))),
+                    (p,left,right) => new VariableCommandParameter(new BiOperandVariable(BiOperandType.AND, left.GetValue().value, right.GetValue().value))),
                 TwoValueRule<AndCommandParameter,BlockConditionCommandParameter,BlockConditionCommandParameter>(
                     requiredLeft<BlockConditionCommandParameter>(), requiredRight<BlockConditionCommandParameter>(),
-                    (p,left,right) => new BlockConditionCommandParameter(new AndBlockCondition(left.GetValue().Value, right.GetValue().Value))),
+                    (p,left,right) => new BlockConditionCommandParameter(new AndBlockCondition(left.GetValue().value, right.GetValue().value))),
 
                 //OrProcessor
                 TwoValueRule<OrCommandParameter,VariableCommandParameter,VariableCommandParameter>(
                     requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
-                    (p,left,right) => new VariableCommandParameter(new BiOperandVariable(BiOperandType.OR, left.GetValue().Value, right.GetValue().Value))),
+                    (p,left,right) => new VariableCommandParameter(new BiOperandVariable(BiOperandType.OR, left.GetValue().value, right.GetValue().value))),
                 TwoValueRule<OrCommandParameter,BlockConditionCommandParameter,BlockConditionCommandParameter>(
                     requiredLeft<BlockConditionCommandParameter>(), requiredRight<BlockConditionCommandParameter>(),
-                    (p,left,right) => new BlockConditionCommandParameter(new OrBlockCondition(left.GetValue().Value, right.GetValue().Value))),
+                    (p,left,right) => new BlockConditionCommandParameter(new OrBlockCondition(left.GetValue().value, right.GetValue().value))),
 
                 //NotProcessor
                 OneValueRule<NotCommandParameter,VariableCommandParameter>(
                     requiredRight<VariableCommandParameter>(),
-                    (p,right) => new VariableCommandParameter(new UniOperandVariable(UniOperandType.NOT, right.GetValue().Value))),
+                    (p,right) => new VariableCommandParameter(new UniOperandVariable(UniOperandType.NOT, right.GetValue().value))),
 
                 //VariableComparisonProcessor
                 TwoValueRule<ComparisonCommandParameter,VariableCommandParameter,VariableCommandParameter>(
                     requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
-                    (p,left,right) => new VariableCommandParameter(new ComparisonVariable(left.GetValue().Value, right.GetValue().Value, new PrimitiveComparator(p.Value)))),
+                    (p,left,right) => new VariableCommandParameter(new ComparisonVariable(left.GetValue().value, right.GetValue().value, new PrimitiveComparator(p.value)))),
 
                 //BlockComparisonProcessor
                 ThreeValueRule<ComparisonCommandParameter,PropertyCommandParameter,DirectionCommandParameter,VariableCommandParameter>(
                     optionalEither<PropertyCommandParameter>(),optionalEither<DirectionCommandParameter>(),optionalRight<VariableCommandParameter>(),
                     (p,prop,dir,var) => var.HasValue() || prop.HasValue(),
                     (p,prop,dir,var) => {
-                        Variable variable = var.HasValue() ? var.GetValue().Value : new StaticVariable(new BooleanPrimitive(true));
+                        Variable variable = var.HasValue() ? var.GetValue().value : new StaticVariable(new BooleanPrimitive(true));
                         PropertyType? property = null;
-                        if(prop.HasValue()) property = prop.GetValue().Value;
+                        if(prop.HasValue()) property = prop.GetValue().value;
                         DirectionType? direction = null;
-                        if(dir.HasValue()) direction = dir.GetValue().Value;
-                        return new BlockConditionCommandParameter(new BlockPropertyCondition(property, direction, new PrimitiveComparator(p.Value), variable));
+                        if(dir.HasValue()) direction = dir.GetValue().value;
+                        return new BlockConditionCommandParameter(new BlockPropertyCondition(property, direction, new PrimitiveComparator(p.value), variable));
                     }),
 
                 //IndexProcessor
                 OneValueRule<IndexCommandParameter,VariableCommandParameter>(
                     requiredRight<VariableCommandParameter>(),
-                    (p,var) => new IndexSelectorCommandParameter(var.GetValue().Value)),
+                    (p,var) => new IndexSelectorCommandParameter(var.GetValue().value)),
 
                 //ConditionalSelectorProcessor
                 TwoValueRule<WithCommandParameter,SelectorCommandParameter, BlockConditionCommandParameter>(
                     requiredLeft<SelectorCommandParameter>(),requiredRight<BlockConditionCommandParameter>(),
-                    (p,selector,condition) => new SelectorCommandParameter(new ConditionalEntityProvider(selector.GetValue().Value, condition.GetValue().Value))),
+                    (p,selector,condition) => new SelectorCommandParameter(new ConditionalEntityProvider(selector.GetValue().value, condition.GetValue().value))),
 
                 //IndexSelectorProcessor
                 OneValueRule<IndexSelectorCommandParameter,SelectorCommandParameter>(
                     requiredLeft<SelectorCommandParameter>(),
-                    (p,selector) => new SelectorCommandParameter(new IndexEntityProvider(selector.GetValue().Value,p.Value))),
+                    (p,selector) => new SelectorCommandParameter(new IndexEntityProvider(selector.GetValue().value,p.value))),
 
                 //PropertyAggregationProcessor
                 ThreeValueRule<PropertyAggregationCommandParameter,SelectorCommandParameter,PropertyCommandParameter,DirectionCommandParameter>(
@@ -166,46 +166,46 @@ namespace IngameScript {
                     (p,selector,property,direction) => selector.HasValue(),
                     (p,selector,prop,dir) => {
                         PropertyType? property = null;
-                        if(prop.HasValue()) property = prop.GetValue().Value;
+                        if(prop.HasValue()) property = prop.GetValue().value;
                         DirectionType? direction = null;
-                        if(dir.HasValue()) direction = dir.GetValue().Value;
-                        return new VariableCommandParameter(new AggregatePropertyVariable(p.Value, selector.GetValue().Value, property, direction));
+                        if(dir.HasValue()) direction = dir.GetValue().value;
+                        return new VariableCommandParameter(new AggregatePropertyVariable(p.value, selector.GetValue().value, property, direction));
                     }),
 
                 //AggregateConditionProcessors
                 TwoValueRule<BlockConditionCommandParameter,AggregationModeCommandParameter,SelectorCommandParameter>(
                     optionalLeft<AggregationModeCommandParameter>(),requiredLeft<SelectorCommandParameter>(),
                     (p,aggregation,selector) => {
-                        AggregationMode mode = aggregation.HasValue() ? aggregation.GetValue().Value : AggregationMode.ALL;
-                        return new VariableCommandParameter(new AggregateConditionVariable(mode, p.Value, selector.GetValue().Value));
+                        AggregationMode mode = aggregation.HasValue() ? aggregation.GetValue().value : AggregationMode.ALL;
+                        return new VariableCommandParameter(new AggregateConditionVariable(mode, p.value, selector.GetValue().value));
                     }),
                 TwoValueRule<BlockConditionCommandParameter,AggregationModeCommandParameter,BlockTypeCommandParameter>(
                     optionalLeft<AggregationModeCommandParameter>(),requiredLeft<BlockTypeCommandParameter>(),
                     (p,aggregation,blockType) => {
-                        AggregationMode mode = aggregation.HasValue() ? aggregation.GetValue().Value : AggregationMode.ALL;
-                        return new VariableCommandParameter(new AggregateConditionVariable(mode, p.Value, new AllEntityProvider(blockType.GetValue().Value)));
+                        AggregationMode mode = aggregation.HasValue() ? aggregation.GetValue().value : AggregationMode.ALL;
+                        return new VariableCommandParameter(new AggregateConditionVariable(mode, p.value, new AllEntityProvider(blockType.GetValue().value)));
                     }),
 
                 //ImplicitAllSelectorProcessor
                 OneValueRule<BlockTypeCommandParameter,GroupCommandParameter>(
                     optionalRight<GroupCommandParameter>(),
-                    (blockType, group) => new SelectorCommandParameter(new AllEntityProvider(blockType.Value))),
+                    (blockType, group) => new SelectorCommandParameter(new AllEntityProvider(blockType.value))),
 
                 //AggregateSelectorProcessor
                 OneValueRule<AggregationModeCommandParameter,SelectorCommandParameter>(
                     requiredRight<SelectorCommandParameter>(),
-                    (aggregation, selector) => aggregation.Value != AggregationMode.NONE && selector.HasValue(),
+                    (aggregation, selector) => aggregation.value != AggregationMode.NONE && selector.HasValue(),
                     (aggregation, selector) => selector.GetValue()),
 
                 //IteratorProcessor
                 OneValueRule<IteratorCommandParameter,VariableCommandParameter>(
                     requiredLeft<VariableCommandParameter>(),
-                    (p,var) => new IterationCommandParameter(var.GetValue().Value)),
+                    (p,var) => new IterationCommandParameter(var.GetValue().value)),
 
                 //IfProcessor
                 OneValueRule<IfCommandParameter,VariableCommandParameter>(
                     requiredRight<VariableCommandParameter>(),
-                    (p,var) => new ConditionCommandParameter(p.inverseCondition ? new UniOperandVariable(UniOperandType.NOT, var.GetValue().Value) : var.GetValue().Value, p.alwaysEvaluate, p.swapCommands)),
+                    (p,var) => new ConditionCommandParameter(p.inverseCondition ? new UniOperandVariable(UniOperandType.NOT, var.GetValue().value) : var.GetValue().value, p.alwaysEvaluate, p.swapCommands)),
 
                 //ActionProcessor
                 BlockCommandProcessor(),
@@ -214,7 +214,7 @@ namespace IngameScript {
                 new BranchingProcessor<SelectorCommandParameter>(
                     TwoValueRule<SelectorCommandParameter,PropertyCommandParameter,DirectionCommandParameter>(
                         requiredEither<PropertyCommandParameter>(), optionalEither<DirectionCommandParameter>(),
-                        (s,p,d) => new VariableCommandParameter(new AggregatePropertyVariable(PropertyAggregatorType.VALUE, s.Value, p.GetValue().Value, d.HasValue() ? d.GetValue().Value : (DirectionType?)null))),
+                        (s,p,d) => new VariableCommandParameter(new AggregatePropertyVariable(PropertyAggregatorType.VALUE, s.value, p.GetValue().value, d.HasValue() ? d.GetValue().value : (DirectionType?)null))),
                     TwoValueRule<SelectorCommandParameter,PropertyCommandParameter,DirectionCommandParameter>(
                         optionalEither<PropertyCommandParameter>(), optionalEither<DirectionCommandParameter>(),
                         (s,p,d) => p.HasValue() || d.HasValue(),//Must have at least one!
@@ -228,14 +228,14 @@ namespace IngameScript {
                 //PrintCommandProcessor
                 OneValueRule<PrintCommandParameter,VariableCommandParameter>(
                     requiredRight<VariableCommandParameter>(),
-                    (p,var) => new CommandReferenceParameter(new PrintCommand(var.GetValue().Value))),
+                    (p,var) => new CommandReferenceParameter(new PrintCommand(var.GetValue().value))),
 
                 //WaitProcessor
                 TwoValueRule<WaitCommandParameter,VariableCommandParameter,UnitCommandParameter>(
                     optionalRight<VariableCommandParameter>(),optionalRight<UnitCommandParameter>(),
                     (p,time,unit) => {
-                        UnitType units = unit.HasValue() ? unit.GetValue().Value : time.HasValue() ? UnitType.SECONDS : UnitType.TICKS;
-                        Variable var = time.HasValue() ? time.GetValue().Value : new StaticVariable(new NumberPrimitive(1));
+                        UnitType units = unit.HasValue() ? unit.GetValue().value : time.HasValue() ? UnitType.SECONDS : UnitType.TICKS;
+                        Variable var = time.HasValue() ? time.GetValue().value : new StaticVariable(new NumberPrimitive(1));
                         return new CommandReferenceParameter(new WaitCommand(var, units));
                     }),
 
@@ -247,7 +247,7 @@ namespace IngameScript {
                         List<VariableCommandParameter> parameters = ((ListValueDataFetcher<VariableCommandParameter>)variables).GetValues();
                         Dictionary<string, Variable> inputParameters = new Dictionary<string, Variable>();
                         for (int i = 0; i < p.functionDefinition.parameterNames.Count; i++) {
-                            inputParameters[p.functionDefinition.parameterNames[i]] = parameters[i].Value;
+                            inputParameters[p.functionDefinition.parameterNames[i]] = parameters[i].value;
                         }
                         Command command = new FunctionCommand(p.functionType, p.functionDefinition, inputParameters);
                         return new CommandReferenceParameter(command);
@@ -256,31 +256,31 @@ namespace IngameScript {
                 //VariableAssignmentProcessor
                 OneValueRule<VariableAssignmentCommandParameter,VariableCommandParameter>(
                     requiredRight<VariableCommandParameter>(),
-                    (p,var) => new CommandReferenceParameter(new VariableAssignmentCommand(p.variableName, var.GetValue().Value, p.useReference, p.isGlobal))),
+                    (p,var) => new CommandReferenceParameter(new VariableAssignmentCommand(p.variableName, var.GetValue().value, p.useReference, p.isGlobal))),
 
                 //SendCommandProcessor
                 //Note: Message to send always comes first: "send <command> to <tag>" is only supported format
                 TwoValueRule<SendCommandParameter,VariableCommandParameter,VariableCommandParameter>(
                     requiredRight<VariableCommandParameter>(),requiredRight<VariableCommandParameter>(),
-                    (p,message,tag) => new CommandReferenceParameter(new SendCommand(message.GetValue().Value, tag.GetValue().Value))),
+                    (p,message,tag) => new CommandReferenceParameter(new SendCommand(message.GetValue().value, tag.GetValue().value))),
 
                 //ListenCommandProcessor
                 OneValueRule<ListenCommandParameter,VariableCommandParameter>(
                     requiredRight<VariableCommandParameter>(),
-                    (p,var) => new CommandReferenceParameter(new ListenCommand(var.GetValue().Value))),
+                    (p,var) => new CommandReferenceParameter(new ListenCommand(var.GetValue().value))),
 
                 //ControlProcessor 
-                NoValueRule<ControlCommandParameter>((p) => new CommandReferenceParameter(new ControlCommand(p.Value))),
+                NoValueRule<ControlCommandParameter>((p) => new CommandReferenceParameter(new ControlCommand(p.value))),
 
                 //IterationProcessor
                 OneValueRule<IterationCommandParameter,CommandReferenceParameter>(
                     requiredEither<CommandReferenceParameter>(),
-                    (p,command) => new CommandReferenceParameter(new MultiActionCommand(new List<Command> {command.GetValue().Value}, p.Value))),
+                    (p,command) => new CommandReferenceParameter(new MultiActionCommand(new List<Command> {command.GetValue().value}, p.value))),
 
                 //QueueProcessor
                 OneValueRule<QueueCommandParameter,CommandReferenceParameter>(
                     requiredRight<CommandReferenceParameter>(),
-                    (p,command) => new CommandReferenceParameter(new QueueCommand(command.GetValue().Value,p.Value))),
+                    (p,command) => new CommandReferenceParameter(new QueueCommand(command.GetValue().value,p.value))),
 
                 //ConditionalCommandProcessor
                 //condition command
@@ -297,14 +297,14 @@ namespace IngameScript {
 
             static CommandParameter ConvertConditionalCommand(ConditionCommandParameter condition, DataFetcher<CommandReferenceParameter> metFetcher,
                 DataFetcher<ElseCommandParameter> otherwise, DataFetcher<CommandReferenceParameter> notMetFetcher) {
-                Command metCommand = metFetcher.GetValue().Value;
-                Command notMetCommand = otherwise.HasValue() ? notMetFetcher.GetValue().Value : new NullCommand();
+                Command metCommand = metFetcher.GetValue().value;
+                Command notMetCommand = otherwise.HasValue() ? notMetFetcher.GetValue().value : new NullCommand();
                 if (condition.swapCommands) {
                     var temp = metCommand;
                     metCommand = notMetCommand;
                     notMetCommand = temp;
                 }
-                Command command = new ConditionalCommand(condition.Value, metCommand, notMetCommand, condition.alwaysEvaluate);
+                Command command = new ConditionalCommand(condition.value, metCommand, notMetCommand, condition.alwaysEvaluate);
                 return new CommandReferenceParameter(command);
             }
 
@@ -345,6 +345,8 @@ namespace IngameScript {
 
                 int processorIndex = 0;
 
+                Debug(String.Join(" ", commandParameters.Select(p => CommandParameterToString(p)).ToList()));
+
                 while (processorIndex < sortedParameterProcessors.Count) {
                     bool revisit = false;
                     bool processed = false;
@@ -359,7 +361,11 @@ namespace IngameScript {
                             } else revisit = true;
                         }
                     }
-                    if (processed) { processorIndex = 0; continue; }
+                    if (processed) {
+                        Debug(String.Join(" ", commandParameters.Select(p => CommandParameterToString(p)).ToList()));
+                        processorIndex = 0;
+                        continue;
+                    }
                     if (!revisit) sortedParameterProcessors.RemoveAt(processorIndex);
                     else processorIndex++;
                 }
@@ -543,11 +549,11 @@ namespace IngameScript {
 
             public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters, List<List<CommandParameter>> branches) {
                 if (p[i] is ValueCommandParameter<String>) {
-                    p[i] = GetParameter(((ValueCommandParameter<String>)p[i]).Value);
+                    p[i] = GetParameter(((ValueCommandParameter<String>)p[i]).value);
                 } else if (p[i] is NumericCommandParameter) {
-                    p[i] = new VariableCommandParameter(new StaticVariable(new NumberPrimitive(((NumericCommandParameter)p[i]).Value)));
+                    p[i] = new VariableCommandParameter(new StaticVariable(new NumberPrimitive(((NumericCommandParameter)p[i]).value)));
                 } else if (p[i] is BooleanCommandParameter) {
-                    p[i] = new VariableCommandParameter(new StaticVariable(new BooleanPrimitive(((BooleanCommandParameter)p[i]).Value)));
+                    p[i] = new VariableCommandParameter(new StaticVariable(new BooleanPrimitive(((BooleanCommandParameter)p[i]).value)));
                 } else {
                     finalParameters = null;
                     return false;
@@ -691,7 +697,7 @@ namespace IngameScript {
                 if (reverseProcessor.f.HasValue()) commandParameters.Add(reverseProcessor.f.GetValue());
                 if (notProcessor.f.HasValue()) {
                     VariableCommandParameter value = extractFirst<VariableCommandParameter>(commandParameters) ?? new VariableCommandParameter(new StaticVariable(new BooleanPrimitive(true)));
-                    commandParameters.Add(new VariableCommandParameter(new UniOperandVariable(UniOperandType.NOT, value.Value)));
+                    commandParameters.Add(new VariableCommandParameter(new UniOperandVariable(UniOperandType.NOT, value.value)));
                 }
 
                 BlockCommand command = new BlockCommand(commandParameters);

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -54,26 +54,31 @@ namespace IngameScript {
             return extracted;
         }
 
-        public interface CommandParameter { }
+        public interface CommandParameter {
+            string Token { get; set; }
+        }
         public interface PrimitiveCommandParameter : CommandParameter { }
-        public class IndexCommandParameter : CommandParameter { }
-        public class GroupCommandParameter : CommandParameter { }
-        public class NotCommandParameter : CommandParameter { }
-        public class AndCommandParameter : CommandParameter { }
-        public class OrCommandParameter : CommandParameter { }
-        public class OpenParenthesisCommandParameter : CommandParameter { }
-        public class CloseParenthesisCommandParameter : CommandParameter { }
-        public class IteratorCommandParameter : CommandParameter { }
-        public class ActionCommandParameter : CommandParameter { }
-        public class ReverseCommandParameter : CommandParameter { }
-        public class RelativeCommandParameter : CommandParameter { }
-        public class WaitCommandParameter : CommandParameter { }
-        public class SendCommandParameter : CommandParameter { }
-        public class ListenCommandParameter : CommandParameter { }
-        public class ElseCommandParameter : CommandParameter { }
-        public class PrintCommandParameter : CommandParameter { }
-        public class SelfCommandParameter : CommandParameter { }
-        public class GlobalCommandParameter : CommandParameter { }
+        public abstract class SimpleCommandParameter : CommandParameter {
+            public string Token { get; set; }
+        }
+        public class IndexCommandParameter : SimpleCommandParameter { }
+        public class GroupCommandParameter : SimpleCommandParameter { }
+        public class NotCommandParameter : SimpleCommandParameter { }
+        public class AndCommandParameter : SimpleCommandParameter { }
+        public class OrCommandParameter : SimpleCommandParameter { }
+        public class OpenParenthesisCommandParameter : SimpleCommandParameter { }
+        public class CloseParenthesisCommandParameter : SimpleCommandParameter { }
+        public class IteratorCommandParameter : SimpleCommandParameter { }
+        public class ActionCommandParameter : SimpleCommandParameter { }
+        public class ReverseCommandParameter : SimpleCommandParameter { }
+        public class RelativeCommandParameter : SimpleCommandParameter { }
+        public class WaitCommandParameter : SimpleCommandParameter { }
+        public class SendCommandParameter : SimpleCommandParameter { }
+        public class ListenCommandParameter : SimpleCommandParameter { }
+        public class ElseCommandParameter : SimpleCommandParameter { }
+        public class PrintCommandParameter : SimpleCommandParameter { }
+        public class SelfCommandParameter : SimpleCommandParameter { }
+        public class GlobalCommandParameter : SimpleCommandParameter { }
 
         public class QueueCommandParameter : ValueCommandParameter<bool> {
             public QueueCommandParameter(bool async) : base(async) {
@@ -93,7 +98,7 @@ namespace IngameScript {
             public AddCommandParameter(BiOperandType value) : base(value) {}
         }
 
-        public class AssignmentCommandParameter : CommandParameter {
+        public class AssignmentCommandParameter : SimpleCommandParameter {
             public bool useReference;
 
             public AssignmentCommandParameter(bool useReference) {
@@ -101,7 +106,7 @@ namespace IngameScript {
             }
         }
 
-        public class VariableAssignmentCommandParameter : CommandParameter {
+        public class VariableAssignmentCommandParameter : SimpleCommandParameter {
             public string variableName;
             public bool useReference;
             public bool isGlobal;
@@ -122,10 +127,14 @@ namespace IngameScript {
         }
 
         public abstract class ValueCommandParameter<T> : CommandParameter {
-            public T Value;
-            public ValueCommandParameter(T value) { this.Value = value; }
-            public override string ToString() {
-                return GetType() + " : " + Value;
+            public T value;
+            public ValueCommandParameter(T v) { value = v; }
+
+            string CommandParameter.Token {
+                get {
+                    return value.ToString();
+                }
+                set {}
             }
         }
 
@@ -172,7 +181,7 @@ namespace IngameScript {
             public FunctionCommandParameter(FunctionType value) : base(value) {}
         }
 
-        public class FunctionDefinitionCommandParameter : CommandParameter {
+        public class FunctionDefinitionCommandParameter : SimpleCommandParameter {
             public FunctionType functionType;
             public FunctionDefinition functionDefinition;
 
@@ -182,14 +191,14 @@ namespace IngameScript {
             }
         }
 
-        public class WithCommandParameter : CommandParameter {
+        public class WithCommandParameter : SimpleCommandParameter {
             public bool inverseCondition;
             public WithCommandParameter(bool inverseCondition) {
                 this.inverseCondition = inverseCondition;
             }
         }
 
-        public class IfCommandParameter : CommandParameter {
+        public class IfCommandParameter : SimpleCommandParameter {
             public bool inverseCondition;
             public bool alwaysEvaluate;
             public bool swapCommands;

--- a/EasyCommands/Commands/Commands.cs
+++ b/EasyCommands/Commands/Commands.cs
@@ -138,7 +138,7 @@ namespace IngameScript {
             public ControlCommand(List<CommandParameter> parameters) {
                 int controlIndex = parameters.FindIndex(p => p is ControlCommandParameter);
                 if (controlIndex < 0) throw new Exception("Control Command must have ControlType");
-                controlType = ((ControlCommandParameter)parameters[controlIndex]).Value;
+                controlType = ((ControlCommandParameter)parameters[controlIndex]).value;
             }
 
             public ControlCommand(ControlType controlType) {
@@ -264,48 +264,48 @@ namespace IngameScript {
                 extract<ActionCommandParameter>(commandParameters);//Extract and ignore
                 SelectorCommandParameter selector = extractFirst<SelectorCommandParameter>(commandParameters);
                 if (selector == null) throw new Exception("SelectorCommandParameter is required for command: " + GetType());
-                entityProvider = selector.Value;
+                entityProvider = selector.value;
             }
 
             public List<BlockCommandHandler> GetHandlers() {
                 return new List<BlockCommandHandler>() {
                     //Primitive Handlers
                     new BlockCommandHandler1<VariableCommandParameter>((b,e,v)=>{
-                        Primitive result = v.Value.GetValue();
+                        Primitive result = v.value.GetValue();
                         PropertyType propertyType = b.GetDefaultProperty(result.GetPrimitiveType());
-                        b.SetPropertyValue(e, propertyType, v.Value.GetValue());
+                        b.SetPropertyValue(e, propertyType, v.value.GetValue());
                     }),
                     new BlockCommandHandler1<PropertyCommandParameter>((b,e,p)=>{
-                        b.SetPropertyValue(e, p.Value, new BooleanPrimitive(true));
+                        b.SetPropertyValue(e, p.value, new BooleanPrimitive(true));
                     }),
                     new BlockCommandHandler1<DirectionCommandParameter>((b,e,d)=>{
-                        PropertyType propertyType = b.GetDefaultProperty(d.Value);
-                        b.MoveNumericPropertyValue(e, propertyType, d.Value);
+                        PropertyType propertyType = b.GetDefaultProperty(d.value);
+                        b.MoveNumericPropertyValue(e, propertyType, d.value);
                     }),
                     new BlockCommandHandler2<PropertyCommandParameter, VariableCommandParameter>((b,e,p,v)=>{
-                        b.SetPropertyValue(e, p.Value, v.Value.GetValue());
+                        b.SetPropertyValue(e, p.value, v.value.GetValue());
                     }),
                     new BlockCommandHandler2<DirectionCommandParameter, VariableCommandParameter>((b,e,d,v)=>{
-                        PropertyType property = b.GetDefaultProperty(d.Value);
-                        b.SetPropertyValue(e, property, d.Value, v.Value.GetValue());
+                        PropertyType property = b.GetDefaultProperty(d.value);
+                        b.SetPropertyValue(e, property, d.value, v.value.GetValue());
                     }),
                     new BlockCommandHandler3<PropertyCommandParameter, DirectionCommandParameter, VariableCommandParameter>((b,e,p,d,v)=>{
-                        b.SetPropertyValue(e,p.Value,d.Value,v.Value.GetValue());
+                        b.SetPropertyValue(e,p.value,d.value,v.value.GetValue());
                     }),
                     new BlockCommandHandler3<PropertyCommandParameter, VariableCommandParameter, RelativeCommandParameter>((b,e,p,v,r)=>{
-                        b.IncrementPropertyValue(e,p.Value,v.Value.GetValue());
+                        b.IncrementPropertyValue(e,p.value,v.value.GetValue());
                     }),
                     new BlockCommandHandler3<DirectionCommandParameter, VariableCommandParameter, RelativeCommandParameter>((b,e,d,v,r)=>{
-                        PropertyType property = b.GetDefaultProperty(d.Value);
-                        b.IncrementPropertyValue(e,property,d.Value,v.Value.GetValue());
+                        PropertyType property = b.GetDefaultProperty(d.value);
+                        b.IncrementPropertyValue(e,property,d.value,v.value.GetValue());
                     }),
                     new BlockCommandHandler4<PropertyCommandParameter, DirectionCommandParameter, VariableCommandParameter, RelativeCommandParameter>((b,e,p,d,v,r)=>{
-                        b.IncrementPropertyValue(e,p.Value,d.Value,v.Value.GetValue());
+                        b.IncrementPropertyValue(e,p.value,d.value,v.value.GetValue());
                     }),
                     new BlockCommandHandler2<PropertyCommandParameter, DirectionCommandParameter>((b,e,p,d)=>{
-                        b.MoveNumericPropertyValue(e, p.Value, d.Value); }),
+                        b.MoveNumericPropertyValue(e, p.value, d.value); }),
                     new BlockCommandHandler2<ReverseCommandParameter, PropertyCommandParameter>((b,e,r,p)=>{
-                        b.ReverseNumericPropertyValue(e, p.Value); }),
+                        b.ReverseNumericPropertyValue(e, p.value); }),
                     new BlockCommandHandler1<ReverseCommandParameter>((b,e,r)=>{
                         PropertyType property = b.GetDefaultProperty(b.GetDefaultDirection());
                         b.ReverseNumericPropertyValue(e, property); }),

--- a/EasyCommands/Commands/EntityProviders.cs
+++ b/EasyCommands/Commands/EntityProviders.cs
@@ -99,7 +99,7 @@ namespace IngameScript {
                 var blockType = extractFirst<BlockTypeCommandParameter>(parameters);
                 isGroup = extractFirst<GroupCommandParameter>(parameters) != null;
                 if (blockType == null) throw new Exception("Cannot parse block type from selector: " + selector);
-                return blockType.Value;
+                return blockType.value;
             }
 
             public override String ToString() {

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -320,7 +320,7 @@ namespace IngameScript {
             while (branches.Count > 0) {
                 branches.AddRange(ParameterProcessorRegistry.Process(branches[0]));
                 if (branches[0].Count == 1 && branches[0][0] is CommandReferenceParameter) {
-                    return ((CommandReferenceParameter)branches[0][0]).Value;
+                    return ((CommandReferenceParameter)branches[0][0]).value;
                 } else {
                     branches.RemoveAt(0);
                 }

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -210,16 +210,15 @@ namespace IngameScript {
         }
 
         static bool ParseCommands() {
-            if (String.IsNullOrWhiteSpace(PROGRAM.Me.CustomData) || !PROGRAM.Me.CustomData.Equals(CUSTOM_DATA)) {
+            if (String.IsNullOrWhiteSpace(PROGRAM.Me.CustomData)) {
+                Info("Welcome to EasyCommands!");
+                Info("Add Commands to Custom Data");
+                return false;
+            } else if (!PROGRAM.Me.CustomData.Equals(CUSTOM_DATA)) {
                 CUSTOM_DATA = PROGRAM.Me.CustomData;
-                COMMAND_STRINGS = CUSTOM_DATA.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.RemoveEmptyEntries)
-                    .Where(line => !line.StartsWith("#"))
+                COMMAND_STRINGS = CUSTOM_DATA.Trim().Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None)
                     .ToList();
-                if (COMMAND_STRINGS.Count == 0) {
-                    Info("Welcome to EasyCommands!");
-                    Info("Add Commands to Custom Data");
-                    return false;
-                }
+
                 Info("Parsing Custom Data");
                 FUNCTIONS.Clear();
                 PROGRAM.ClearAllThreads();
@@ -234,7 +233,11 @@ namespace IngameScript {
 
         static void ParseFunctions(List<String> commandStrings) {
             List<int> functionIndices = new List<int>();
-            if (!commandStrings[0].StartsWith(":")) { commandStrings.Insert(0, ":main"); }
+            int implicitMainOffset = 1;
+            if (!commandStrings[0].StartsWith(":")) {
+                commandStrings.Insert(0, ":main");
+                implicitMainOffset--;
+            }
 
             for (int i = commandStrings.Count - 1; i >= 0; i--) {
                 Trace("Command String: " + commandStrings[i]);
@@ -256,11 +259,12 @@ namespace IngameScript {
             //Parse Function Commands and add to Definitions
             int toParse = FUNCTION_PARSE_AMOUNT;
             foreach (int i in functionIndices) {
+                int startingLineNumber = i + 1 + implicitMainOffset;
                 String functionString = commandStrings[i].Remove(0, 1).Trim();
                 List<Token> nameAndParams = ParseTokens(functionString);
                 String functionName = nameAndParams[0].original;
                 Info("Parsing Function: " + functionName);
-                Command command = ParseCommand(commandStrings.GetRange(i + 1, commandStrings.Count - (i + 1)).Select(str => new CommandLine(str)).ToList(), 0, true);
+                Command command = ParseCommand(commandStrings.GetRange(i + 1, commandStrings.Count - (i + 1)).Select(str => new CommandLine(str)).ToList(), 0, true, ref startingLineNumber);
                 commandStrings.RemoveRange(i, commandStrings.Count - i);
                 if (!(command is MultiActionCommand)) { command = new MultiActionCommand(new List<Command> { command }); }
                 FUNCTIONS[functionName].function = (MultiActionCommand)command;
@@ -270,7 +274,7 @@ namespace IngameScript {
             }
         }
 
-        static Command ParseCommand(List<CommandLine> commandStrings, int index, bool parseSiblings) {
+        static Command ParseCommand(List<CommandLine> commandStrings, int index, bool parseSiblings, ref int startingLineNumber) {
             List<Command> resolvedCommands = new List<Command>();
             while (index < commandStrings.Count - 1)//Parse Sibling & Child Commands, if any
             {
@@ -279,37 +283,44 @@ namespace IngameScript {
                 if (current.Depth > next.Depth) break;//End, break
                 if (current.Depth < next.Depth) {//I'm a parent of next line
                     Trace("Parsing Sub Command @ Index: " + (index + 1));
-                    current.CommandParameters.Add(new CommandReferenceParameter(ParseCommand(commandStrings, index + 1, true)));
+                    startingLineNumber++;
+                    current.CommandParameters.Add(new CommandReferenceParameter(ParseCommand(commandStrings, index + 1, true, ref startingLineNumber)));
                     continue;
                 }
-                if (next.CommandParameters[0] is ElseCommandParameter) {//Handle Otherwise
+                if (next.CommandParameters.Count > 0 && next.CommandParameters[0] is ElseCommandParameter) {//Handle Otherwise
                     Trace("Handling Otherwise @ index: " + index);
                     current.CommandParameters.Add(next.CommandParameters[0]);
                     next.CommandParameters.RemoveAt(0);
-                    current.CommandParameters.Add(new CommandReferenceParameter(ParseCommand(commandStrings, index + 1, false)));
+                    startingLineNumber++;
+                    current.CommandParameters.Add(new CommandReferenceParameter(ParseCommand(commandStrings, index + 1, false, ref startingLineNumber)));
                     continue;
                 }
 
                 if (!parseSiblings) break;//Only parsing myself
-                Trace("Parsing Sibling Command @ Index: " + index);
-                resolvedCommands.Add(ParseCommand(current.CommandParameters));
+                if (!current.ShouldIgnore()) {
+                    Trace("Parsing Sibling Command @ Index: " + index);
+                    resolvedCommands.Add(ParseCommand(current.CommandParameters, startingLineNumber));
+                }
                 commandStrings.RemoveAt(index);
+                startingLineNumber++;
             }
 
             //Parse Last one, which has become current
-            Trace("Parsing Final Command @ Index: " + index);
-            resolvedCommands.Add(ParseCommand(commandStrings[index].CommandParameters));
+            if(!commandStrings[index].ShouldIgnore()) {
+                Trace("Parsing Final Command @ Index: " + index);
+                resolvedCommands.Add(ParseCommand(commandStrings[index].CommandParameters, startingLineNumber));
+            }
             commandStrings.RemoveAt(index);
 
             if (resolvedCommands.Count > 1) return new MultiActionCommand(resolvedCommands); else return resolvedCommands[0];
         }
 
-        public static Command ParseCommand(String commandLine) {
-            return ParseCommand(ParseCommandParameters(ParseTokens(commandLine)));
+        public static Command ParseCommand(String commandLine, int lineNumber = 0) {
+            return ParseCommand(ParseCommandParameters(ParseTokens(commandLine)), lineNumber);
         }
 
-        private static Command ParseCommand(List<CommandParameter> parameters) {
-            Trace("Parsing Command");
+        private static Command ParseCommand(List<CommandParameter> parameters, int lineNumber) {
+            Trace("Parsing Command at line: " + lineNumber);
             Trace("Pre Processed Parameters:");
             parameters.ForEach(param => Trace("Type: " + param.GetType()));
 
@@ -326,7 +337,7 @@ namespace IngameScript {
                 }
             }
 
-            throw new Exception("Unable to parse command from command parameters!");
+            throw new Exception("Unable to parse command from command parameters at line number: " + lineNumber);
         }
 
         class CommandLine {
@@ -338,6 +349,10 @@ namespace IngameScript {
                 Depth = commandString.TakeWhile(Char.IsWhiteSpace).Count();
                 CommandParameters = ParseCommandParameters(ParseTokens(commandString));
                 CommandString = commandString;
+            }
+
+            public bool ShouldIgnore() {
+                return String.IsNullOrWhiteSpace(CommandString) || CommandString.StartsWith("#");
             }
         }
 


### PR DESCRIPTION
This commit implements much better processor debugging support with 2 commits:

1 - Add the parse tree to the debug output.  When LogLevel is set to Debug, the output will contain detailed information about how the command was parsed.

2 - Add line numbers to the exception output when a command cannot be parsed.  

This commit implements #13 