### PR TITLE
Fixed Parameters Not Set Correctly in While Loops

### DIFF
--- a/EasyCommands.Tests/ScriptTests/MultiThreadingTests.cs
+++ b/EasyCommands.Tests/ScriptTests/MultiThreadingTests.cs
@@ -290,5 +290,25 @@ print 'Variable is: ' + {a}
                 Assert.AreEqual("Variable is: 1", test.Logger[1]);
             }
         }
+
+        [TestMethod]
+        public void asyncCommandParametersAreProperlySetInAWhileLoop() {
+            String script = @"
+:main
+assign ""i"" to 0
+while {i} < 2
+  async call printLocalVariable {i}
+  assign ""i"" to {i} + 1
+
+:printLocalVariable ""a""
+print 'Variable is: ' + {a}
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+                Assert.IsTrue(test.Logger.Contains("Variable is: 0"));
+                Assert.IsTrue(test.Logger.Contains("Variable is: 1"));
+            }
+        }
     }
 }

--- a/EasyCommands/Commands/Commands.cs
+++ b/EasyCommands/Commands/Commands.cs
@@ -46,7 +46,7 @@ namespace IngameScript {
             }
 
             public override bool Execute() {
-                Thread thread = new Thread(command, "Queued", "Unknown");
+                Thread thread = new Thread(command.Clone(), "Queued", "Unknown");
                 thread.threadVariables = new Dictionary<string, Variable>(PROGRAM.GetCurrentThread().threadVariables);
                 if (async) {
                     PROGRAM.QueueAsyncThread(thread);
@@ -105,6 +105,7 @@ namespace IngameScript {
                 }
             }
             public override Command Clone() { return new FunctionCommand(type, functionDefinition, inputParameters); }
+            public override void Reset() => function = null;
         }
 
         public class VariableAssignmentCommand : Command {


### PR DESCRIPTION
This simple commit fixes a bug where parameters would only get set once in a while loop, leading to failures if the command inside the while loop is a queue command
call.