### PR TITLE
Added simple multi-line text support

### DIFF
--- a/EasyCommands.Tests/ScriptTests/TextSurfaceBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/TextSurfaceBlockTests.cs
@@ -25,6 +25,25 @@ set the ""text panel"" display text to ""Hello World""
         }
 
         [TestMethod]
+        public void SetTextPanelTextMultiLine() {
+            String script = @"
+set the ""text panel"" display text to ""Hello World\nThis is my life""
+";
+
+            var expectedText = "Hello World\nThis is my life";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockTextPanel = new Mock<IMyTextPanel>();
+                test.MockBlocksOfType("text panel", mockTextPanel);
+
+                test.RunUntilDone();
+
+                mockTextPanel.Verify(b => b.WriteText(expectedText, false));
+            }
+        }
+
+
+        [TestMethod]
         public void SetProgrammableBlockDisplayText() {
             String script = @"
 set the ""test program"" display @ 0 text to ""Hello World""

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -224,11 +224,11 @@ namespace IngameScript {
             }
 
             public override object GetValue() {
-                return stringValue;
+                return GetStringValue();
             }
 
             public String GetStringValue() {
-                return stringValue;
+                return stringValue.Replace("\\n", "\n");
             }
         }
 


### PR DESCRIPTION
This commit simply treats all instances of "\n" as a carriage return by replacing those strings before returning the primitive value.

It also adds a simple test proving the behavior is working as expected

This commit implements #69 