### PR TITLE
Remove statics

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Malware.MDKUtilities;
+using IngameScript;
 using static IngameScript.Program;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
@@ -7,7 +9,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
     public class AggregateBlockPropertyProcessorTests {
         [TestMethod]
         public void AssignCountOfBlocks() {
-            var command = ParseCommand("assign \"a\" to count of the \"forward guns\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to count of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -17,7 +20,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSumOfBlocks() {
-            var command = ParseCommand("assign \"a\" to sum of the \"forward guns\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to sum of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -27,7 +31,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAverageOfBlocks() {
-            var command = ParseCommand("assign \"a\" to average of the \"forward guns\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to average of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -37,7 +42,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignMinimumOfBlocks() {
-            var command = ParseCommand("assign \"a\" to minimum of the \"forward guns\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to minimum of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -47,7 +53,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignMaximumOfBlocks() {
-            var command = ParseCommand("assign \"a\" to maximum of the \"forward guns\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to maximum of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -57,7 +64,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSumOfBlocksWithProperty() {
-            var command = ParseCommand("assign \"a\" to sum of the \"forward guns\" range");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to sum of the \"forward guns\" range");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -67,7 +75,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAverageOfBlocksWithPropertyFirst() {
-            var command = ParseCommand("assign \"a\" to avg range of the \"forward guns\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to avg range of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -77,7 +86,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAvgOfBlocksWithSelectorFirst() {
-            var command = ParseCommand("assign \"a\" to \"forward guns\" average range");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to \"forward guns\" average range");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -87,7 +97,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAvgOfBlocksWithAggregationFirst() {
-            var command = ParseCommand("assign \"a\" to \"forward guns\" range average");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to \"forward guns\" range average");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -97,7 +108,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAvgOfBlocksUsingImplicitSelector() {
-            var command = ParseCommand("assign \"a\" to the average gun range");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to the average gun range");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -109,7 +121,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAvgOfBlocksUsingImplicitAggregate() {
-            var command = ParseCommand("assign \"a\" to the \"test gun\" range");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to the \"test gun\" range");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -121,7 +134,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAvgOfBlocksUsingImplicitAggregateInParentheses() {
-            var command = ParseCommand("assign \"a\" to the ( \"test gun\" range )" );
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to the ( \"test gun\" range )" );
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -133,7 +147,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAvgOfBlocksUsingImplicitAggregateAndImplicitSelector() {
-            var command = ParseCommand("assign \"a\" to the gun range");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to the gun range");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -145,7 +160,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAvgOfBlocksUsingImplicitAggregateAndMySelector() {
-            var command = ParseCommand("assign \"a\" to my location");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to my location");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);

--- a/EasyCommands.Tests/ParameterParsingTests/BlockCommandProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/BlockCommandProcessorTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Malware.MDKUtilities;
+using IngameScript;
 using static IngameScript.Program;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
@@ -7,70 +9,77 @@ namespace EasyCommands.Tests.ParameterParsingTests {
     public class SimpleBlockCommandParameterProcessorTests {
         [TestMethod]
         public void SimpleBlockCommandWithProperty() {
-            var command = ParseCommand("turn on the \"pistons\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on the \"pistons\"");
             Assert.IsTrue(command is BlockCommand);
 
-            command = ParseCommand("turn the \"pistons\" on");
+            command = program.ParseCommand("turn the \"pistons\" on");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithNotProperty() {
-            var command = ParseCommand("tell the \"rockets\" not to shoot");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("tell the \"rockets\" not to shoot");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithValue() {
-            var command = ParseCommand("set the \"pistons\" to 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("set the \"pistons\" to 2");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithVariableValue() {
-            var command = ParseCommand("set the \"pistons\" to {b}");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("set the \"pistons\" to {b}");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithDirection() {
-            var command = ParseCommand("retract the \"pistons\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("retract the \"pistons\"");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
-        public void SimpleBlockCommandWithReverse()
-        {
-            var command = ParseCommand("reverse the \"pistons\"");
+        public void SimpleBlockCommandWithReverse() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("reverse the \"pistons\"");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithPropertyAndVariable() {
-            var command = ParseCommand("set the \"pistons\" height to 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("set the \"pistons\" height to 2");
             Assert.IsTrue(command is BlockCommand);
 
-            command = ParseCommand("set the height of the \"pistons\" to 2");
+            command = program.ParseCommand("set the height of the \"pistons\" to 2");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithDirectionAndVariable() {
-            var command = ParseCommand("rotate the \"rotors\" clockwise to 30");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("rotate the \"rotors\" clockwise to 30");
             Assert.IsTrue(command is BlockCommand);
 
-            command = ParseCommand("set the \"rotors\" angle to 30 clockwise");
+            command = program.ParseCommand("set the \"rotors\" angle to 30 clockwise");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithDirectionAndPropertyAndVariable() {
-            var command = ParseCommand("rotate the \"rotors\" angle clockwise to 30");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("rotate the \"rotors\" angle clockwise to 30");
             Assert.IsTrue(command is BlockCommand);
 
-            command = ParseCommand("set the \"rotors\" angle to 30 clockwise");
+            command = program.ParseCommand("set the \"rotors\" angle to 30 clockwise");
             Assert.IsTrue(command is BlockCommand);
         }
-
     }
 }

--- a/EasyCommands.Tests/ParameterParsingTests/BooleanLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/BooleanLogicParameterProcessorTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Malware.MDKUtilities;
+using IngameScript;
 using static IngameScript.Program;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
@@ -7,61 +9,71 @@ namespace EasyCommands.Tests.ParameterParsingTests {
     public class BooleanLogicParameterProcessorTests {
         [TestMethod]
         public void AndSimpleVariableCondition() {
-            var command = ParseCommand("if true and false turn on the \"pistons\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if true and false turn on the \"pistons\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void AndBlockCondition() {
-            var command = ParseCommand("if the \"batteries\" are on but are not recharging turn on the \"generators\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if the \"batteries\" are on but are not recharging turn on the \"generators\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void AndAggregateConditions() {
-            var command = ParseCommand("if the \"batteries\" are on but none of the \"batteries\" is recharging turn on the \"generators\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if the \"batteries\" are on but none of the \"batteries\" is recharging turn on the \"generators\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void OrSimpleVariableCondition() {
-            var command = ParseCommand("if true or false turn on the \"pistons\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if true or false turn on the \"pistons\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void OrBlockCondition() {
-            var command = ParseCommand("if any of the \"batteries\" ratio is less than 0.5 or is recharging turn on the \"pistons\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if any of the \"batteries\" ratio is less than 0.5 or is recharging turn on the \"pistons\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void OrAggregateConditions() {
-            var command = ParseCommand("if the \"batteries\" are off or any of the \"batteries\" ratio is less than 0.25 turn on the \"generators\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if the \"batteries\" are off or any of the \"batteries\" ratio is less than 0.25 turn on the \"generators\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void NotVariableCondition() {
-            var command = ParseCommand("if not true turn on the \"pistons\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if not true turn on the \"pistons\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void NotBlockCondition() {
-            var command = ParseCommand("if not true turn on the \"pistons\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if not true turn on the \"pistons\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void NotAggregateBlockCondition() {
-            var command = ParseCommand("if not all of the \"batteries\" ratio > 0.75 turn on the \"generators\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if not all of the \"batteries\" ratio > 0.75 turn on the \"generators\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void ImplicitSelectorUsedInAggregateCondition() {
-            var command = ParseCommand("if any battery ratio < 0.75 turn on the generators");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if any battery ratio < 0.75 turn on the generators");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
             Assert.IsTrue(conditionalCommand.Condition is AggregateConditionVariable);
@@ -81,7 +93,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ImplicitSelectorUsedInAggregateConditionWithNot() {
-            var command = ParseCommand("if not all of the batteries ratio < 0.75 turn on the generators");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if not all of the batteries ratio < 0.75 turn on the generators");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
             Assert.IsTrue(conditionalCommand.Condition is UniOperandVariable);

--- a/EasyCommands.Tests/ParameterParsingTests/ConditionalParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/ConditionalParameterProcessorTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Malware.MDKUtilities;
+using IngameScript;
 using static IngameScript.Program;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
@@ -7,7 +9,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
     public class ConditionalParameterProcessorTests {
         [TestMethod]
         public void SimpleBooleanCondition() {
-            var command = ParseCommand("if true set the \"rotors\" height to 5");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if true set the \"rotors\" height to 5");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
             Assert.IsTrue(conditionalCommand.Condition is StaticVariable);
@@ -19,7 +22,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SimpleVariableCondition() {
-            var command = ParseCommand("if {a} set the \"rotors\" height to 5");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if {a} set the \"rotors\" height to 5");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
             Assert.IsTrue(conditionalCommand.Condition is InMemoryVariable);
@@ -29,7 +33,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void VariableComparisonCondition() {
-            var command = ParseCommand("if 3 > 2 set the \"rotors\" height to 5");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if 3 > 2 set the \"rotors\" height to 5");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
             Assert.IsTrue(conditionalCommand.Condition is ComparisonVariable);
@@ -43,7 +48,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void BlockConditionWithProperty() {
-            var command = ParseCommand("if the \"batteries\" are recharging set the \"rotors\" height to 5");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if the \"batteries\" are recharging set the \"rotors\" height to 5");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
             Assert.IsTrue(conditionalCommand.Condition is AggregateConditionVariable);

--- a/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using VRageMath;
+using Malware.MDKUtilities;
+using IngameScript;
 using static IngameScript.Program;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
@@ -9,7 +11,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAbsoluteValue() {
-            var command = ParseCommand("assign a to abs -3 + 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to abs -3 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -20,7 +23,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSin() {
-            var command = ParseCommand("assign a to sin 1.5708");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to sin 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is UniOperandVariable);
@@ -31,7 +35,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignCos() {
-            var command = ParseCommand("assign a to cos 1.5708");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to cos 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is UniOperandVariable);
@@ -42,7 +47,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignTan() {
-            var command = ParseCommand("assign a to tan 1.5708");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to tan 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is UniOperandVariable);
@@ -53,7 +59,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignASin() {
-            var command = ParseCommand("assign a to asin 1.5708");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to asin 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is UniOperandVariable);
@@ -64,7 +71,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignACos() {
-            var command = ParseCommand("assign a to acos 1.5708");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to acos 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is UniOperandVariable);
@@ -75,7 +83,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignATan() {
-            var command = ParseCommand("assign a to atan 1.5708");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to atan 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is UniOperandVariable);
@@ -86,7 +95,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignRoundDown() {
-            var command = ParseCommand("assign a to round 5.4");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to round 5.4");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is UniOperandVariable);
@@ -97,7 +107,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignRoundUp() {
-            var command = ParseCommand("assign a to round 5.6");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to round 5.6");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is UniOperandVariable);
@@ -108,7 +119,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAbsoluteValueVector() {
-            var command = ParseCommand("assign a to abs \"1:0:0\" + 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to abs \"1:0:0\" + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -124,7 +136,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSquaeRootValue() {
-            var command = ParseCommand("assign a to sqrt 9 + 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to sqrt 9 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -135,7 +148,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSquareRootValueVector() {
-            var command = ParseCommand("assign a to sqrt \"9:0:0\" + 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to sqrt \"9:0:0\" + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -151,7 +165,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleAddition() {
-            var command = ParseCommand("assign a to 3 + 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to 3 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -162,7 +177,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleSubtraction() {
-            var command = ParseCommand("assign a to 3 - 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to 3 - 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -173,7 +189,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleMultiplication() {
-            var command = ParseCommand("assign a to 3 * 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to 3 * 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -184,7 +201,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorMultiplication() {
-            var command = ParseCommand("assign a to \"0:1:0\" * \"1:0:0\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"0:1:0\" * \"1:0:0\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -195,7 +213,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorDotProduct() {
-            var command = ParseCommand("assign a to \"0:1:0\" . \"1:0:0\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"0:1:0\" . \"1:0:0\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -206,7 +225,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleDivision() {
-            var command = ParseCommand("assign a to 6 / 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to 6 / 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -216,9 +236,9 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         }
 
         [TestMethod]
-        public void AssignSimpleMod()
-        {
-            var command = ParseCommand("assign a to 5 % 2");
+        public void AssignSimpleMod() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to 5 % 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -229,7 +249,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorMod() {
-            var command = ParseCommand("assign a to \"1:1:0\" % \"0:1:0\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"1:1:0\" % \"0:1:0\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -240,7 +261,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleAdditionVariable() {
-            var command = ParseCommand("assign a to {b} + 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to {b} + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -252,7 +274,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleSubtractionVariable() {
-            var command = ParseCommand("assign a to {b} - 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to {b} - 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -264,7 +287,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleMultiplicationVariable() {
-            var command = ParseCommand("assign a to {b} * 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to {b} * 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -276,7 +300,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleDivisionVariable() {
-            var command = ParseCommand("assign a to {b} / 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to {b} / 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -288,7 +313,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void MultiplicationBeforeAddition() {
-            var command = ParseCommand("assign a to 4 * 2 + 3");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to 4 * 2 + 3");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -303,7 +329,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void DivisionBeforeAddition() {
-            var command = ParseCommand("assign a to 4 / 2 + 3");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to 4 / 2 + 3");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -318,7 +345,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AdditionBeforeVariableComparison() {
-            var command = ParseCommand("assign a to {b} + 1 > 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to {b} + 1 > 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is ComparisonVariable);
@@ -329,7 +357,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AdditionBeforeBooleanLogic() {
-            var command = ParseCommand("assign a to {b} + 1 and {c}");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to {b} + 1 and {c}");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -341,7 +370,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AdditionUsedAsBlockConditionVariable() {
-            var command = ParseCommand("if the \"rotor\" angle > {a} + 30 set the \"rotor\" angle to {a}");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if the \"rotor\" angle > {a} + 30 set the \"rotor\" angle to {a}");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand assignment = (ConditionalCommand)command;
             Assert.IsTrue(assignment.Condition is AggregateConditionVariable);
@@ -353,7 +383,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignColor() {
-            var command = ParseCommand("assign a to \"red\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"red\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -363,7 +394,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignColorFromHex() {
-            var command = ParseCommand("assign a to \"#ff0000\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"#ff0000\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -373,7 +405,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAddedColors() {
-            var command = ParseCommand("assign a to \"#ff0000\" + \"#00ff00\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"#ff0000\" + \"#00ff00\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -383,7 +416,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSubtractedColors() {
-            var command = ParseCommand("assign a to \"#ffff00\" - \"#00ff00\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"#ffff00\" - \"#00ff00\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -393,7 +427,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignMultipliedColor() {
-            var command = ParseCommand("assign a to \"#112233\" * 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"#112233\" * 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -403,7 +438,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignDividedColor() {
-            var command = ParseCommand("assign a to \"#224466\" / 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"#224466\" / 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -413,7 +449,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignNotColor() {
-            var command = ParseCommand("assign a to not \"red\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to not \"red\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();

--- a/EasyCommands.Tests/ParameterParsingTests/ParenthesisParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/ParenthesisParameterProcessorTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Malware.MDKUtilities;
+using IngameScript;
 using static IngameScript.Program;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
@@ -7,19 +9,22 @@ namespace EasyCommands.Tests.ParameterParsingTests {
     public class ParenthesisParameterProcessorTests {
         [TestMethod]
         public void BasicVariableParentheses() {
-            var command = ParseCommand("set the \"pistons\" height to ( {a} + {b} )");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("set the \"pistons\" height to ( {a} + {b} )");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void MultipleVariableParenthesis() {
-            var command = ParseCommand("if ( {a} > {b} ) set the \"pistons\" height to ( {a} + {b} )");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if ( {a} > {b} ) set the \"pistons\" height to ( {a} + {b} )");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void EmbeddedParanthesis() {
-            var command = ParseCommand("if ( ( {a} + {b} ) > {c} ) set the \"pistons\" height to ( {a} + {b} )");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("if ( ( {a} + {b} ) > {c} ) set the \"pistons\" height to ( {a} + {b} )");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
             Variable condition = conditionalCommand.Condition;

--- a/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Malware.MDKUtilities;
+using IngameScript;
 using static IngameScript.Program;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
@@ -7,7 +9,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
     public class SelectorLogicParameterProcessorTests {
         [TestMethod]
         public void BasicSelector() {
-            var command = ParseCommand("recharge the \"batteries\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("recharge the \"batteries\"");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is SelectorEntityProvider);
@@ -20,7 +23,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ConditionalSelector() {
-            var command = ParseCommand("recharge \"batteries\" whose ratio < 0.5");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("recharge \"batteries\" whose ratio < 0.5");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is ConditionalEntityProvider);
@@ -28,7 +32,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IndexSelector() {
-            var command = ParseCommand("turn on \"batteries\" @ 0");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on \"batteries\" @ 0");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is IndexEntityProvider);
@@ -36,7 +41,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void InLineIndexSelector() {
-            var command = ParseCommand("turn on \"batteries\" @0");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on \"batteries\" @0");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is IndexEntityProvider);
@@ -44,7 +50,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ConditionalIndexSelector() {
-            var command = ParseCommand("set the \"batteries\" whose ratio < 0.5 @0 to recharge");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("set the \"batteries\" whose ratio < 0.5 @0 to recharge");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is IndexEntityProvider);
@@ -54,7 +61,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void LastBlockTypeImpliedIsUsed() {
-            var command = ParseCommand("turn on the \"Boom Door Program\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on the \"Boom Door Program\"");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is SelectorEntityProvider);
@@ -64,7 +72,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void VariableSelector() {
-            var command = ParseCommand("turn on the [a] sirens");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on the [a] sirens");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is SelectorEntityProvider);
@@ -77,7 +86,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ImplicitVariableSelector() {
-            var command = ParseCommand("turn on the [a]");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on the [a]");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is SelectorEntityProvider);
@@ -89,7 +99,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void MySelector() {
-            var command = ParseCommand("assign a to my average location");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to my average location");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
@@ -100,7 +111,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void MySelectorWithBlockType() {
-            var command = ParseCommand("set my display @0 text to \"hello world\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("set my display @0 text to \"hello world\"");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is IndexEntityProvider);
@@ -111,7 +123,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AllSelector() {
-            var command = ParseCommand("set all piston height to 0");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("set all piston height to 0");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is AllEntityProvider);
@@ -121,7 +134,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AllSelectorGroup() {
-            var command = ParseCommand("set the height of all pistons to 0");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("set the height of all pistons to 0");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is AllEntityProvider);
@@ -131,7 +145,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AllSelectorGroupWithCondition() {
-            var command = ParseCommand("recharge all batteries whose ratio < 0.25");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("recharge all batteries whose ratio < 0.25");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is ConditionalEntityProvider);
@@ -143,7 +158,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ImplicitAllSelector() {
-            var command = ParseCommand("turn on the light");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on the light");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is AllEntityProvider);
@@ -153,7 +169,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ImplicitAllGroupSelector() {
-            var command = ParseCommand("turn on the lights");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on the lights");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
             Assert.IsTrue(bc.entityProvider is AllEntityProvider);

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleCommandProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleCommandProcessorTests.cs
@@ -12,7 +12,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
     public class SimpleCommandProcessorTests {
         [TestMethod]
         public void PrintCommand() {
-            var command = ParseCommand("print 'Hello World'");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("print 'Hello World'");
             Assert.IsTrue(command is PrintCommand);
             PrintCommand printCommand = (PrintCommand)command;
             Assert.AreEqual("Hello World", CastString(printCommand.variable.GetValue()).GetStringValue());
@@ -20,7 +21,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void PrintCommandVariable() {
-            var command = ParseCommand("print {a}");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("print {a}");
             Assert.IsTrue(command is PrintCommand);
             PrintCommand printCommand = (PrintCommand)command;
             Assert.IsTrue(printCommand.variable is InMemoryVariable);
@@ -30,7 +32,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ListenCommand() {
-            var command = ParseCommand("listen \"garageDoors\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("listen \"garageDoors\"");
             Assert.IsTrue(command is ListenCommand);
             ListenCommand listenCommand = (ListenCommand)command;
             Assert.AreEqual("garageDoors", CastString(listenCommand.tag.GetValue()).GetStringValue());
@@ -38,7 +41,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SendCommand() {
-            var command = ParseCommand("send \"goto openDoors\" to \"garageDoors\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("send \"goto openDoors\" to \"garageDoors\"");
             Assert.IsTrue(command is SendCommand);
             SendCommand sendCommand = (SendCommand)command;
             Assert.AreEqual("garageDoors", CastString(sendCommand.tag.GetValue()).GetStringValue());
@@ -47,9 +51,9 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void FunctionCommand() {
-            MDKFactory.CreateProgram<Program>();
-            PROGRAM.functions["listen"] = new FunctionDefinition("listen", new List<string>());
-            var command = ParseCommand("goto \"listen\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            program.functions["listen"] = new FunctionDefinition("listen", new List<string>());
+            var command = program.ParseCommand("goto \"listen\"");
             Assert.IsTrue(command is FunctionCommand);
             FunctionCommand functionCommand = (FunctionCommand)command;
             Assert.AreEqual("listen", functionCommand.functionDefinition.functionName);
@@ -58,9 +62,9 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void FunctionCommandFromExplicitString() {
-            MDKFactory.CreateProgram<Program>();
-            PROGRAM.functions["listen"] = new FunctionDefinition("listen", new List<string>());
-            var command = ParseCommand("goto 'listen'");
+            var program = MDKFactory.CreateProgram<Program>();
+            program.functions["listen"] = new FunctionDefinition("listen", new List<string>());
+            var command = program.ParseCommand("goto 'listen'");
             Assert.IsTrue(command is FunctionCommand);
             FunctionCommand functionCommand = (FunctionCommand)command;
             Assert.AreEqual("listen", functionCommand.functionDefinition.functionName);
@@ -69,9 +73,9 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void FunctionCommandWithParameters() {
-            MDKFactory.CreateProgram<Program>();
-            PROGRAM.functions["listen"] = new FunctionDefinition("listen", new List<string>() { "a", "b" });
-            var command = ParseCommand("goto \"listen\" 2 3");
+            var program = MDKFactory.CreateProgram<Program>();
+            program.functions["listen"] = new FunctionDefinition("listen", new List<string>() { "a", "b" });
+            var command = program.ParseCommand("goto \"listen\" 2 3");
             Assert.IsTrue(command is FunctionCommand);
             FunctionCommand functionCommand = (FunctionCommand)command;
             Assert.AreEqual("listen", functionCommand.functionDefinition.functionName);
@@ -82,7 +86,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void WaitCommandNoArguments() {
-            var command = ParseCommand("wait");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("wait");
             Assert.IsTrue(command is WaitCommand);
             WaitCommand waitCommand = (WaitCommand)command;
             Assert.AreEqual(1, CastNumber(waitCommand.waitInterval.GetValue()).GetNumericValue());
@@ -91,7 +96,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void WaitCommandInterval() {
-            var command = ParseCommand("wait 3");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("wait 3");
             Assert.IsTrue(command is WaitCommand);
             WaitCommand waitCommand = (WaitCommand)command;
             Assert.AreEqual(3, CastNumber(waitCommand.waitInterval.GetValue()).GetNumericValue());
@@ -100,7 +106,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void WaitCommandIntervalUnits() {
-            var command = ParseCommand("wait 3 ticks");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("wait 3 ticks");
             Assert.IsTrue(command is WaitCommand);
             WaitCommand waitCommand = (WaitCommand)command;
             Assert.AreEqual(3, CastNumber(waitCommand.waitInterval.GetValue()).GetNumericValue());
@@ -109,7 +116,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IterateSimpleCommand() {
-            var command = ParseCommand("print \"hello world\" 3 times");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("print \"hello world\" 3 times");
             Assert.IsTrue(command is MultiActionCommand);
             MultiActionCommand iterateCommand = (MultiActionCommand)command;
             Assert.AreEqual(3f, iterateCommand.loopCount.GetValue().GetValue());
@@ -122,7 +130,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IterateSimpleCommandAfter() {
-            var command = ParseCommand("for 3 times print \"hello world\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("for 3 times print \"hello world\"");
             Assert.IsTrue(command is MultiActionCommand);
             MultiActionCommand iterateCommand = (MultiActionCommand)command;
             Assert.AreEqual(3f, iterateCommand.loopCount.GetValue().GetValue());
@@ -135,7 +144,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void StopCommand() {
-            var command = ParseCommand("stop");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("stop");
             Assert.IsTrue(command is ControlCommand);
             ControlCommand controlCommand = (ControlCommand)command;
             Assert.AreEqual(ControlType.STOP, controlCommand.controlType);
@@ -143,7 +153,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void StartCommand() {
-            var command = ParseCommand("start");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("start");
             Assert.IsTrue(command is ControlCommand);
             ControlCommand controlCommand = (ControlCommand)command;
             Assert.AreEqual(ControlType.START, controlCommand.controlType);
@@ -151,7 +162,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void RestartCommand() {
-            var command = ParseCommand("restart");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("restart");
             Assert.IsTrue(command is ControlCommand);
             ControlCommand controlCommand = (ControlCommand)command;
             Assert.AreEqual(ControlType.RESTART, controlCommand.controlType);
@@ -159,7 +171,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void RepeatCommand() {
-            var command = ParseCommand("repeat");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("repeat");
             Assert.IsTrue(command is ControlCommand);
             ControlCommand controlCommand = (ControlCommand)command;
             Assert.AreEqual(ControlType.REPEAT, controlCommand.controlType);
@@ -167,7 +180,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void PauseCommand() {
-            var command = ParseCommand("pause");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("pause");
             Assert.IsTrue(command is ControlCommand);
             ControlCommand controlCommand = (ControlCommand)command;
             Assert.AreEqual(ControlType.PAUSE, controlCommand.controlType);
@@ -175,7 +189,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ResumeCommand() {
-            var command = ParseCommand("resume");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("resume");
             Assert.IsTrue(command is ControlCommand);
             ControlCommand controlCommand = (ControlCommand)command;
             Assert.AreEqual(ControlType.START, controlCommand.controlType);

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using VRageMath;
+using Malware.MDKUtilities;
+using IngameScript;
 using static IngameScript.Program;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
@@ -9,7 +11,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariable() {
-            var command = ParseCommand("assign \"a\" to 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.AreEqual("a", assignCommand.variableName);
@@ -19,7 +22,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignGlobalVariable() {
-            var command = ParseCommand("assign global \"a\" to 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign global \"a\" to 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.AreEqual("a", assignCommand.variableName);
@@ -30,7 +34,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableFromExplicitString() {
-            var command = ParseCommand("assign 'a' to 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign 'a' to 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.AreEqual("a", assignCommand.variableName);
@@ -40,7 +45,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableCaseIsPreserved() {
-            var command = ParseCommand("assign \"a\" to {variableName}");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"a\" to {variableName}");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.AreEqual("a", assignCommand.variableName);
@@ -51,7 +57,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void LockVariable() {
-            var command = ParseCommand("bind \"a\" to {b} is 2");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("bind \"a\" to {b} is 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.AreEqual("a", assignCommand.variableName);
@@ -64,7 +71,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ParseSimpleVector() {
-            var command = ParseCommand("assign a to \"53573.9750085028:-26601.8512032533:12058.8229348438\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"53573.9750085028:-26601.8512032533:12058.8229348438\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is StaticVariable);
@@ -78,7 +86,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ParseVectorFromGPSCoordinate() {
-            var command = ParseCommand("assign a to \"GPS:surface:53573.9750085028:-26601.8512032533:12058.8229348438:#FF75C9F1:\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"GPS:surface:53573.9750085028:-26601.8512032533:12058.8229348438:#FF75C9F1:\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignCommand.variable is StaticVariable);
@@ -92,13 +101,15 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToSelectorProperty() {
-            var command = ParseCommand("assign \"vector\" to avg \"Main Cockpit\" position");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"vector\" to avg \"Main Cockpit\" position");
             Assert.IsTrue(command is VariableAssignmentCommand);
         }
 
         [TestMethod]
         public void AssignVariableToSelectorString() {
-            var command = ParseCommand("assign \"mySelector\" to \"Main Cockpit\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign \"mySelector\" to \"Main Cockpit\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
             Assert.AreEqual("Main Cockpit", assignmentCommand.variable.GetValue().GetValue());

--- a/EasyCommands.Tests/ScriptTests/ScriptTest.cs
+++ b/EasyCommands.Tests/ScriptTests/ScriptTest.cs
@@ -21,9 +21,9 @@ namespace EasyCommands.Tests.ScriptTests
     /// </summary>
     class ScriptTest : IDisposable
     {
+        public Program program;
         MockGridTerminalSystem mockGrid;
-        private Program program;
-        private Mock<IMyProgrammableBlock> me;
+        Mock<IMyProgrammableBlock> me;
 
         /// <summary>
         /// Counter of how many times the given script has been invoked by the test engine.
@@ -39,7 +39,6 @@ namespace EasyCommands.Tests.ScriptTests
         {
             Logger = new List<String>();
             RunCounter = 0;
-            Program.FUNCTION_PARSE_AMOUNT = 1000;
 
             // Setup the CUSTOM_DATA to return the given script
             // And other required config for mocking
@@ -51,9 +50,8 @@ namespace EasyCommands.Tests.ScriptTests
             config.ProgrammableBlock = me.Object;
             config.Echo = (message) => Logger.Add(message);
             program = MDKFactory.CreateProgram<Program>(config);
-
-            Program.LOG_LEVEL = Program.LogLevel.SCRIPT_ONLY;
-            Program.FUNCTION_PARSE_AMOUNT = 1000;
+            program.functionParseAmount = 1000;
+            program.logLevel = Program.LogLevel.SCRIPT_ONLY;
 
             // Default behavior for broadcast messages
             // TODO: Replace this with mock objects passed to config setup in Program
@@ -152,7 +150,6 @@ namespace EasyCommands.Tests.ScriptTests
         public void Dispose()
         {
             // TODO: Unset any static changes, etc
-            Program.LOG_LEVEL = LogLevel.INFO;
         }
 
         private void SetupMockBlocksByType<T>(string name, Mock<T>[] blockMocks) where T : class, IMyTerminalBlock

--- a/EasyCommands.Tests/ScriptTests/SimpleCommandExecutionTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleCommandExecutionTests.cs
@@ -50,7 +50,7 @@ print 'Hello World'
             String script = "";
 
             using (var test = new ScriptTest(script)) {
-                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.program.logLevel = Program.LogLevel.INFO;
                 test.RunOnce();
                 Assert.AreEqual(2, test.Logger.Count);
                 Assert.AreEqual("Welcome to EasyCommands!", test.Logger[0]);

--- a/EasyCommands.Tests/ScriptTests/SimpleLoggingTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleLoggingTests.cs
@@ -13,7 +13,7 @@ print 'Hello World'
 'Hello World'
 ";
             using (var test = new ScriptTest(script)) {
-                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.program.logLevel = Program.LogLevel.INFO;
 
                 test.RunOnce();
 
@@ -28,7 +28,7 @@ print 'Hello World'
 'Hello World'
 ";
             using (var test = new ScriptTest(script)) {
-                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.program.logLevel = Program.LogLevel.INFO;
                 test.RunOnce();
 
                 Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 2"));
@@ -43,7 +43,7 @@ if (true)
   'Hello World'
 ";
             using (var test = new ScriptTest(script)) {
-                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.program.logLevel = Program.LogLevel.INFO;
                 test.RunOnce();
 
                 Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 3"));
@@ -59,7 +59,7 @@ if (true)
 'Hello World'
 ";
             using (var test = new ScriptTest(script)) {
-                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.program.logLevel = Program.LogLevel.INFO;
                 test.RunOnce();
 
                 Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 4"));
@@ -76,7 +76,7 @@ if (true)
 'Hello World'
 ";
             using (var test = new ScriptTest(script)) {
-                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.program.logLevel = Program.LogLevel.INFO;
                 test.RunOnce();
 
                 Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 5"));
@@ -96,7 +96,7 @@ if (true)
 'Hello World'
 ";
             using (var test = new ScriptTest(script)) {
-                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.program.logLevel = Program.LogLevel.INFO;
                 test.RunOnce();
 
                 Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 8"));
@@ -115,7 +115,7 @@ if (true)
 'Hello World'
 ";
             using (var test = new ScriptTest(script)) {
-                Program.LOG_LEVEL = Program.LogLevel.INFO;
+                test.program.logLevel = Program.LogLevel.INFO;
                 test.RunOnce();
 
                 Assert.IsTrue(test.Logger.Contains("Unable to parse command from command parameters at line number: 7"));
@@ -128,7 +128,7 @@ if (true)
 print 'Total: ' + ( 2 + 5 )
 ";
             using (var test = new ScriptTest(script)) {
-                Program.LOG_LEVEL = Program.LogLevel.DEBUG;
+                test.program.logLevel = Program.LogLevel.DEBUG;
 
                 test.RunOnce();
 

--- a/EasyCommands.Tests/TokenParsingTests/ParenthesisParsingTests.cs
+++ b/EasyCommands.Tests/TokenParsingTests/ParenthesisParsingTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Malware.MDKUtilities;
+using IngameScript;
 using static IngameScript.Program;
 
 namespace EasyCommands.Tests.TokenParsingTests {
@@ -7,7 +9,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
     public class ParenthesisParsingTests {
         [TestMethod]
         public void TestBasicParenthesis() {
-            var tokens = ParseTokens("test ( string )");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("test ( string )");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("(", tokens[1].original);
@@ -17,7 +20,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         [TestMethod]
         public void TestParenthesesMissingSpaces() {
-            var tokens = ParseTokens("test (string) there");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("test (string) there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("(", tokens[1].original);
@@ -28,7 +32,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         [TestMethod]
         public void TestMissingSpaceBeforeOpeningParenthesis() {
-            var tokens = ParseTokens("test (string )there");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("test (string )there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("(", tokens[1].original);
@@ -39,7 +44,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         [TestMethod]
         public void TestMissingSpaceAfterClosingParenthesis() {
-            var tokens = ParseTokens("test( string ) there");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("test( string ) there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("(", tokens[1].original);
@@ -50,7 +56,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         [TestMethod]
         public void TestEmbeddedParenthesesMissingSpaces() {
-            var tokens = ParseTokens("test ((string) there)");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("test ((string) there)");
             Assert.AreEqual(7, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("(", tokens[1].original);

--- a/EasyCommands.Tests/TokenParsingTests/StringParsingTests.cs
+++ b/EasyCommands.Tests/TokenParsingTests/StringParsingTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using Malware.MDKUtilities;
+using IngameScript;
 using static IngameScript.Program;
 
 namespace EasyCommands.Tests.TokenParsingTests {
@@ -7,7 +9,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
     public class StringParsingTests {
         [TestMethod]
         public void BasicStrings() {
-            var tokens = ParseTokens("turn on the rotors");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("turn on the rotors");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("turn", tokens[0].original);
             Assert.AreEqual("on", tokens[1].original);
@@ -17,7 +20,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         [TestMethod]
         public void StringWithDoubleQuotes() {
-            var tokens = ParseTokens("turn on the \"test rotors\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("turn on the \"test rotors\"");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("turn", tokens[0].original);
             Assert.AreEqual("on", tokens[1].original);
@@ -27,7 +31,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         [TestMethod]
         public void MultipleDoubleQuotes() {
-            var tokens = ParseTokens("tell the \"test program\" to \"run gotoTest\"");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("tell the \"test program\" to \"run gotoTest\"");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
             Assert.AreEqual("the", tokens[1].original);
@@ -38,7 +43,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         [TestMethod]
         public void SingleQuotes() {
-            var tokens = ParseTokens("tell the program to 'run gotoTest'");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("tell the program to 'run gotoTest'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
             Assert.AreEqual("the", tokens[1].original);
@@ -49,7 +55,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         [TestMethod]
         public void MultipleSingleQuotes() {
-            var tokens = ParseTokens("tell the 'test program' to 'run gotoTest'");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("tell the 'test program' to 'run gotoTest'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
             Assert.AreEqual("the", tokens[1].original);
@@ -60,7 +67,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         [TestMethod]
         public void SingleQuotesAndDoubleQuotes() {
-            var tokens = ParseTokens("tell the \"test program\" to 'run gotoTest'");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("tell the \"test program\" to 'run gotoTest'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
             Assert.AreEqual("the", tokens[1].original);
@@ -71,7 +79,8 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         [TestMethod]
         public void DoubleQuotesInsideSingleQuotes() {
-            var tokens = ParseTokens("tell the \"test program\" to 'run \"goto testFunction\"'");
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.ParseTokens("tell the \"test program\" to 'run \"goto testFunction\"'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
             Assert.AreEqual("the", tokens[1].original);

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -19,113 +19,6 @@ using VRageMath;
 
 namespace IngameScript {
     partial class Program {
-        //Configuration.  Keep all words lowercase
-        static String[] ignoreWords = { "the", "than", "turned", "block", "to", "from", "then", "of", "either", "for" };
-        static String[] groupWords = { "blocks", "group" };
-        static String[] activateWords = { "move", "go", "on", "begin", "true" };
-        static String[] deactivateWords = { "off", "terminate", "exit", "cancel", "end", "false" };
-        static String[] reverseWords = { "reverse" };
-        static String[] increaseWords = { "increase", "raise", "extend", "expand" };
-        static String[] decreaseWords = { "decrease", "retract", "reduce" };
-        static String[] upWords = { "up", "upward", "upwards", "upper" };
-        static String[] downWords = { "down", "downward", "downwards", "lower" };
-        static String[] leftWords = { "left", "lefthand" };
-        static String[] rightWords = { "right", "righthand" };
-        static String[] forwardWords = { "forward", "forwards", "front" };
-        static String[] backwardWords = { "backward", "backwards", "back" };
-        static String[] clockwiseWords = { "clockwise", "clock" };
-        static String[] counterclockwiseWords = { "counter", "counterclock", "counterclockwise" };
-        static String[] actionWords = { "tell", "turn", "rotate", "set" };
-
-        static String[] relativeWords = { "by" };
-        static String[] increaseRelativeWords = { "add" };
-        static String[] decreaseRelativeWords = { "subtact" };
-        static String[] heightWords = { "height", "length" };
-        static String[] angleWords = { "angle" };
-        static String[] speedWords = { "speed", "velocity", "rate", "pace" };
-        static String[] waitWords = { "wait", "hold" };
-        static String[] connectWords = { "connect", "join", "attach", "connected", "joined", "attached", "dock", "docked" };
-        static String[] disconnectWords = { "disconnect", "separate", "detach", "disconnected", "separated", "detached", "undock", "undocked" };
-
-        static String[] lockWords = { "lock", "locked", "freeze" };
-        static String[] unlockWords = { "unlock", "unlocked", "unfreeze" };
-
-        static String[] ifWords = { "if" };
-        static String[] elseWords = { "else", "otherwise" };
-        static String[] unlessWords = { "unless" };
-        static String[] whileWords = { "while" };
-        static String[] untilWords = { "until" };
-        static String[] whenWords = { "when" };
-        static String[] asyncWords = { "async", "background", "parallel" };
-        static String[] queueWords = { "queue", "schedule" };
-        static String[] withWords = { "that", "with", "which", "whose" };
-        static String[] withoutWords = { "without" };
-
-        static String[] lessWords = { "less", "<", "below" };
-        static String[] lessEqualWords = { "<=" };
-        static String[] equalWords = { "is", "are", "equal", "equals", "=", "==" };
-        static String[] greaterEqualWords = { ">=" };
-        static String[] greaterWords = { "greater", ">", "above", "more" };
-
-        static String[] anyWords = { "any" };
-        static String[] allWords = { "all", "every", "each" };
-        static String[] noneWords = { "none" };
-
-        static String[] andWords = { "and", "&", "&&", "but", "yet" };
-        static String[] orWords = { "or", "|", "||" };
-        static String[] notWords = { "not", "!", "isn't", "isnt", "aren't", "arent" };
-        static String[] openParenthesisWords = { "(" };
-        static String[] closeParenthesisWords = { ")" };
-
-        static String[] runWords = { "run", "execute" };
-        static String[] runningWords = { "running", "executing" };
-        static String[] stoppedWords = { "stopped", "terminated" };
-        static String[] pausedWords = { "paused", "halted" };
-        static String[] completeWords = { "done", "complete", "finished", "built" };
-        static String[] progressWords = { "progress", "completion" };
-        static String[] directionWords = { "direction" };
-        static String[] positionWords = { "coordinates", "position", "location" };
-        static String[] openWords = { "open", "opened" };
-        static String[] closeWords = { "close", "closed", "shut" };
-        static String[] targetWords = { "target", "destination", "waypoint" };
-        static String[] targetVelocityWords = { "targetvelocity" };
-        static String[] strengthWords = { "strength", "force", "gravity" };
-        static String[] gosubKeywords = { "call", "gosub" };
-        static String[] gotoKeywords = { "goto" };
-
-        static String[] listenKeywords = { "listen", "channel" };
-        static String[] sendKeywords = { "send", "broadcast" };
-
-        static String[] fontKeywords = { "fontsize", "size" };
-        static String[] colorKeywords = { "color" };
-        static String[] textKeywords = { "text", "message" };
-
-        static String[] blinkIntervalKeywords = { "blinkinterval", "blinkInterval", "interval" };
-        static String[] blinkLengthKeywords = { "blinklength", "blinkLength" };
-        static String[] blinkOffsetKeywords = { "blinkoffset", "blinkOffset" };
-        static String[] intensityKeywords = { "intensity" };
-        static String[] falloffKeywrods = { "falloff" };
-
-        static String[] powerKeywords = { "power" };
-        static String[] soundKeywords = { "music", "song" };
-        static String[] volumeKeywords = { "volume" };
-        static String[] rangeKeywords = { "range", "distance", "limit", "radius" };
-        static String[] iterationKeywords = { "times", "iterations" };
-        static String[] triggerWords = { "trigger", "triggered", "trip", "tripped", "deploy", "deployed", "shoot", "shooting", "shot" };
-        static String[] consumeWords = { "consume", "stockpile", "depressurize", "depressurized", "gather", "intake", "recharge", "recharging" };
-        static String[] produceWords = { "produce", "pressurize", "pressurized", "supply", "generate", "discharge", "discharging" };
-        static String[] ratioWords = { "ratio", "percentage", "percent" };
-        static String[] inputWords = { "input", "pilot", "user" };
-        static String[] rollInputWords = { "roll", "rollInput" };
-        static String[] autoWords = { "auto", "refill", "drain", "draining" };
-        static String[] overrideWords = { "override", "overrides", "overridden" };
-
-        static String[] assignWords = { "assign", "allocate", "designate" };
-        static String[] globalWords = { "global" };
-        static String[] bindWords = { "bind", "tie", "link" };
-        static String[] printWords = { "print", "log", "echo", "write" };
-        static String[] selfWords = { "my", "self", "this" };
-
         static bool Initialized = false;
 
         static Dictionary<String, UnitType> unitTypeWords = new Dictionary<String, UnitType>()
@@ -334,98 +227,123 @@ namespace IngameScript {
         private static Dictionary<String, List<CommandParameter>> propertyWords = new Dictionary<string, List<CommandParameter>>();
 
         public static void InitializeParsers() {
+            //Configuration.  Keep all words lowercase
             if (Initialized) return;
-            AddWords(groupWords, new GroupCommandParameter());
-            AddWords(activateWords, new BooleanCommandParameter(true));
-            AddWords(deactivateWords, new BooleanCommandParameter(false));
-            AddWords(increaseWords, new ActionCommandParameter(), new DirectionCommandParameter(DirectionType.UP));
-            AddWords(increaseRelativeWords, new ActionCommandParameter(), new RelativeCommandParameter(), new DirectionCommandParameter(DirectionType.UP));
-            AddWords(decreaseWords, new ActionCommandParameter(), new DirectionCommandParameter(DirectionType.DOWN));
-            AddWords(decreaseRelativeWords, new ActionCommandParameter(), new RelativeCommandParameter(), new DirectionCommandParameter(DirectionType.DOWN));
-            AddWords(upWords, new DirectionCommandParameter(DirectionType.UP));
-            AddWords(downWords, new DirectionCommandParameter(DirectionType.DOWN));
-            AddWords(leftWords, new DirectionCommandParameter(DirectionType.LEFT));
-            AddWords(rightWords, new DirectionCommandParameter(DirectionType.RIGHT));
-            AddWords(forwardWords, new DirectionCommandParameter(DirectionType.FORWARD));
-            AddWords(backwardWords, new DirectionCommandParameter(DirectionType.BACKWARD));
-            AddWords(clockwiseWords, new DirectionCommandParameter(DirectionType.CLOCKWISE));
-            AddWords(counterclockwiseWords, new DirectionCommandParameter(DirectionType.COUNTERCLOCKWISE));
-            AddWords(actionWords, new ActionCommandParameter());
-            AddWords(reverseWords, new ReverseCommandParameter());
-            AddWords(relativeWords, new RelativeCommandParameter());
-            AddWords(heightWords, new PropertyCommandParameter(PropertyType.HEIGHT));
-            AddWords(angleWords, new PropertyCommandParameter(PropertyType.ANGLE));
-            AddWords(speedWords, new PropertyCommandParameter(PropertyType.VELOCITY));
-            AddWords(connectWords, new PropertyCommandParameter(PropertyType.CONNECTED));
-            AddWords(disconnectWords, new PropertyCommandParameter(PropertyType.CONNECTED), new BooleanCommandParameter(false));
-            AddWords(lockWords, new PropertyCommandParameter(PropertyType.LOCKED));
-            AddWords(unlockWords, new PropertyCommandParameter(PropertyType.LOCKED), new BooleanCommandParameter(false));
-            AddWords(waitWords, new WaitCommandParameter());
-            AddWords(ifWords, new IfCommandParameter(false, false, false));
-            AddWords(unlessWords, new IfCommandParameter(true, false, false));
-            AddWords(whileWords, new IfCommandParameter(false, true, false));
-            AddWords(untilWords, new IfCommandParameter(true, true, false));
-            AddWords(whenWords, new IfCommandParameter(true, true, true));
-            AddWords(queueWords, new QueueCommandParameter(false));
-            AddWords(asyncWords, new QueueCommandParameter(true));
-            AddWords(elseWords, new ElseCommandParameter());
-            AddWords(withWords, new WithCommandParameter(false));
-            AddWords(withoutWords, new WithCommandParameter(true));
-            AddWords(lessWords, new ComparisonCommandParameter(ComparisonType.LESS));
-            AddWords(lessEqualWords, new ComparisonCommandParameter(ComparisonType.LESS_OR_EQUAL));
-            AddWords(equalWords, new ComparisonCommandParameter(ComparisonType.EQUAL));
-            AddWords(greaterEqualWords, new ComparisonCommandParameter(ComparisonType.GREATER_OR_EQUAL));
-            AddWords(greaterWords, new ComparisonCommandParameter(ComparisonType.GREATER));
-            AddWords(anyWords, new AggregationModeCommandParameter(AggregationMode.ANY));
-            AddWords(allWords, new AggregationModeCommandParameter(AggregationMode.ALL));
-            AddWords(noneWords, new AggregationModeCommandParameter(AggregationMode.NONE));
-            AddWords(andWords, new AndCommandParameter());
-            AddWords(orWords, new OrCommandParameter());
-            AddWords(notWords, new NotCommandParameter());
-            AddWords(openParenthesisWords, new OpenParenthesisCommandParameter());
-            AddWords(closeParenthesisWords, new CloseParenthesisCommandParameter());
-            AddWords(runWords, new PropertyCommandParameter(PropertyType.RUN));
-            AddWords(runningWords, new PropertyCommandParameter(PropertyType.RUNNING));
-            AddWords(stoppedWords, new PropertyCommandParameter(PropertyType.STOPPED));
-            AddWords(pausedWords, new PropertyCommandParameter(PropertyType.PAUSED));
-            AddWords(completeWords, new PropertyCommandParameter(PropertyType.COMPLETE));
-            AddWords(progressWords, new PropertyCommandParameter(PropertyType.RATIO));
-            AddWords(openWords, new PropertyCommandParameter(PropertyType.OPEN), new BooleanCommandParameter(true));
-            AddWords(closeWords, new PropertyCommandParameter(PropertyType.OPEN), new BooleanCommandParameter(false));
-            AddWords(gosubKeywords, new FunctionCommandParameter(FunctionType.GOSUB));
-            AddWords(gotoKeywords, new FunctionCommandParameter(FunctionType.GOTO));
-            AddWords(listenKeywords, new ListenCommandParameter());
-            AddWords(sendKeywords, new SendCommandParameter());
-            AddWords(fontKeywords, new PropertyCommandParameter(PropertyType.FONT_SIZE));
-            AddWords(textKeywords, new PropertyCommandParameter(PropertyType.TEXT));
-            AddWords(colorKeywords, new PropertyCommandParameter(PropertyType.COLOR));
-            AddWords(powerKeywords, new PropertyCommandParameter(PropertyType.POWER));
-            AddWords(soundKeywords, new PropertyCommandParameter(PropertyType.SOUND));
-            AddWords(volumeKeywords, new PropertyCommandParameter(PropertyType.VOLUME));
-            AddWords(rangeKeywords, new PropertyCommandParameter(PropertyType.RANGE));
-            AddWords(blinkIntervalKeywords, new PropertyCommandParameter(PropertyType.BLINK_INTERVAL));
-            AddWords(blinkLengthKeywords, new PropertyCommandParameter(PropertyType.BLINK_LENGTH));
-            AddWords(blinkOffsetKeywords, new PropertyCommandParameter(PropertyType.BLINK_OFFSET));
-            AddWords(intensityKeywords, new PropertyCommandParameter(PropertyType.INTENSITY));
-            AddWords(falloffKeywrods, new PropertyCommandParameter(PropertyType.FALLOFF));
-            AddWords(iterationKeywords, new IteratorCommandParameter());
-            AddWords(triggerWords, new PropertyCommandParameter(PropertyType.TRIGGER));
-            AddWords(produceWords, new PropertyCommandParameter(PropertyType.PRODUCE));
-            AddWords(consumeWords, new PropertyCommandParameter(PropertyType.PRODUCE), new BooleanCommandParameter(false));
-            AddWords(ratioWords, new PropertyCommandParameter(PropertyType.RATIO));
-            AddWords(inputWords, new PropertyCommandParameter(PropertyType.MOVE_INPUT));
-            AddWords(rollInputWords, new PropertyCommandParameter(PropertyType.ROLL_INPUT));
-            AddWords(autoWords, new PropertyCommandParameter(PropertyType.AUTO));
-            AddWords(overrideWords, new PropertyCommandParameter(PropertyType.OVERRIDE));
-            AddWords(directionWords, new PropertyCommandParameter(PropertyType.DIRECTION));
-            AddWords(positionWords, new PropertyCommandParameter(PropertyType.POSITION));
-            AddWords(targetWords, new PropertyCommandParameter(PropertyType.TARGET));
-            AddWords(targetVelocityWords, new PropertyCommandParameter(PropertyType.TARGET_VELOCITY));
-            AddWords(strengthWords, new PropertyCommandParameter(PropertyType.STRENGTH));
-            AddWords(assignWords, new AssignmentCommandParameter(false));
-            AddWords(globalWords, new GlobalCommandParameter());
-            AddWords(bindWords, new AssignmentCommandParameter(true));
-            AddWords(printWords, new PrintCommandParameter());
+
+            //Ignored words that have no command parameters
+            AddWords(Words("the", "than", "turned", "block", "to", "from", "then", "of", "either", "for"));
+
+            //Selector Related Words
+            AddWords(Words("blocks", "group"), new GroupCommandParameter());
+            AddWords(Words("my", "self", "this"), new SelfCommandParameter());
+
+            //Direction Words
+            AddWords(Words("up", "upward", "upwards", "upper"), new DirectionCommandParameter(DirectionType.UP));
+            AddWords(Words("down", "downward", "downwards", "lower"), new DirectionCommandParameter(DirectionType.DOWN));
+            AddWords(Words("left", "lefthand"), new DirectionCommandParameter(DirectionType.LEFT));
+            AddWords(Words("right", "righthand"), new DirectionCommandParameter(DirectionType.RIGHT));
+            AddWords(Words("forward", "forwards", "front"), new DirectionCommandParameter(DirectionType.FORWARD));
+            AddWords(Words("backward", "backwards", "back"), new DirectionCommandParameter(DirectionType.BACKWARD));
+            AddWords(Words("clockwise", "clock"), new DirectionCommandParameter(DirectionType.CLOCKWISE));
+            AddWords(Words("counter", "counterclock", "counterclockwise"), new DirectionCommandParameter(DirectionType.COUNTERCLOCKWISE));
+
+            //Action Words
+            AddWords(Words("move", "go", "tell", "turn", "rotate", "set"), new ActionCommandParameter());
+            AddWords(Words("increase", "raise", "extend", "expand"), new ActionCommandParameter(), new DirectionCommandParameter(DirectionType.UP));
+            AddWords(Words("add"), new ActionCommandParameter(), new RelativeCommandParameter(), new DirectionCommandParameter(DirectionType.UP));
+            AddWords(Words("subtact"), new ActionCommandParameter(), new RelativeCommandParameter(), new DirectionCommandParameter(DirectionType.DOWN));
+            AddWords(Words("decrease", "retract", "reduce"), new ActionCommandParameter(), new DirectionCommandParameter(DirectionType.DOWN));
+            AddWords(Words("reverse"), new ReverseCommandParameter());
+            AddWords(Words("by"), new RelativeCommandParameter());
+
+            //Value Words
+            AddWords(Words("on", "begin", "true"), new BooleanCommandParameter(true));
+            AddWords(Words("off", "terminate", "exit", "cancel", "end", "false"), new BooleanCommandParameter(false));
+
+            //Property Words
+            AddWords(Words("height", "length"), new PropertyCommandParameter(PropertyType.HEIGHT));
+            AddWords(Words("angle"), new PropertyCommandParameter(PropertyType.ANGLE));
+            AddWords(Words("speed", "velocity", "rate", "pace"), new PropertyCommandParameter(PropertyType.VELOCITY));
+            AddWords(Words("connect", "join", "attach", "connected", "joined", "attached", "dock", "docked"), new PropertyCommandParameter(PropertyType.CONNECTED));
+            AddWords(Words("disconnect", "separate", "detach", "disconnected", "separated", "detached", "undock", "undocked"), new PropertyCommandParameter(PropertyType.CONNECTED), new BooleanCommandParameter(false));
+            AddWords(Words("lock", "locked", "freeze"), new PropertyCommandParameter(PropertyType.LOCKED));
+            AddWords(Words("unlock", "unlocked", "unfreeze"), new PropertyCommandParameter(PropertyType.LOCKED), new BooleanCommandParameter(false));
+            AddWords(Words("run", "execute"), new PropertyCommandParameter(PropertyType.RUN));
+            AddWords(Words("running", "executing"), new PropertyCommandParameter(PropertyType.RUNNING));
+            AddWords(Words("stopped", "terminated"), new PropertyCommandParameter(PropertyType.STOPPED));
+            AddWords(Words("paused", "halted"), new PropertyCommandParameter(PropertyType.PAUSED));
+            AddWords(Words("done", "complete", "finished", "built"), new PropertyCommandParameter(PropertyType.COMPLETE));
+            AddWords(Words("progress", "completion"), new PropertyCommandParameter(PropertyType.RATIO));
+            AddWords(Words("open", "opened"), new PropertyCommandParameter(PropertyType.OPEN), new BooleanCommandParameter(true));
+            AddWords(Words("close", "closed", "shut"), new PropertyCommandParameter(PropertyType.OPEN), new BooleanCommandParameter(false));
+            AddWords(Words("fontsize", "size"), new PropertyCommandParameter(PropertyType.FONT_SIZE));
+            AddWords(Words("text", "message"), new PropertyCommandParameter(PropertyType.TEXT));
+            AddWords(Words("color"), new PropertyCommandParameter(PropertyType.COLOR));
+            AddWords(Words("power"), new PropertyCommandParameter(PropertyType.POWER));
+            AddWords(Words("music", "song"), new PropertyCommandParameter(PropertyType.SOUND));
+            AddWords(Words("volume"), new PropertyCommandParameter(PropertyType.VOLUME));
+            AddWords(Words("range", "distance", "limit", "radius"), new PropertyCommandParameter(PropertyType.RANGE));
+            AddWords(Words("blinkinterval", "blinkInterval", "interval"), new PropertyCommandParameter(PropertyType.BLINK_INTERVAL));
+            AddWords(Words("blinklength", "blinkLength"), new PropertyCommandParameter(PropertyType.BLINK_LENGTH));
+            AddWords(Words("blinkoffset", "blinkOffset"), new PropertyCommandParameter(PropertyType.BLINK_OFFSET));
+            AddWords(Words("intensity"), new PropertyCommandParameter(PropertyType.INTENSITY));
+            AddWords(Words("falloff"), new PropertyCommandParameter(PropertyType.FALLOFF));
+            AddWords(Words("times", "iterations"), new IteratorCommandParameter());
+            AddWords(Words("trigger", "triggered", "trip", "tripped", "deploy", "deployed", "shoot", "shooting", "shot"), new PropertyCommandParameter(PropertyType.TRIGGER));
+            AddWords(Words("produce", "pressurize", "pressurized", "supply", "generate", "discharge", "discharging"), new PropertyCommandParameter(PropertyType.PRODUCE));
+            AddWords(Words("consume", "stockpile", "depressurize", "depressurized", "gather", "intake", "recharge", "recharging"), new PropertyCommandParameter(PropertyType.PRODUCE), new BooleanCommandParameter(false));
+            AddWords(Words("ratio", "percentage", "percent"), new PropertyCommandParameter(PropertyType.RATIO));
+            AddWords(Words("input", "pilot", "user"), new PropertyCommandParameter(PropertyType.MOVE_INPUT));
+            AddWords(Words("roll", "rollInput"), new PropertyCommandParameter(PropertyType.ROLL_INPUT));
+            AddWords(Words("auto", "refill", "drain", "draining"), new PropertyCommandParameter(PropertyType.AUTO));
+            AddWords(Words("override", "overrides", "overridden"), new PropertyCommandParameter(PropertyType.OVERRIDE));
+            AddWords(Words("direction"), new PropertyCommandParameter(PropertyType.DIRECTION));
+            AddWords(Words("coordinates", "position", "location"), new PropertyCommandParameter(PropertyType.POSITION));
+            AddWords(Words("target", "destination", "waypoint"), new PropertyCommandParameter(PropertyType.TARGET));
+            AddWords(Words("targetvelocity"), new PropertyCommandParameter(PropertyType.TARGET_VELOCITY));
+            AddWords(Words("strength", "force", "gravity"), new PropertyCommandParameter(PropertyType.STRENGTH));
+
+            //Special Command Words
+            AddWords(Words("wait", "hold"), new WaitCommandParameter());
+            AddWords(Words("call", "gosub"), new FunctionCommandParameter(FunctionType.GOSUB));
+            AddWords(Words("goto"), new FunctionCommandParameter(FunctionType.GOTO));
+            AddWords(Words("listen", "channel"), new ListenCommandParameter());
+            AddWords(Words("send", "broadcast"), new SendCommandParameter());
+            AddWords(Words("assign", "allocate", "designate"), new AssignmentCommandParameter(false));
+            AddWords(Words("global"), new GlobalCommandParameter());
+            AddWords(Words("bind", "tie", "link"), new AssignmentCommandParameter(true));
+            AddWords(Words("print", "log", "echo", "write"), new PrintCommandParameter());
+            AddWords(Words("queue", "schedule"), new QueueCommandParameter(false));
+            AddWords(Words("async", "background", "parallel"), new QueueCommandParameter(true));
+
+            //Conditional Words
+            AddWords(Words("if"), new IfCommandParameter(false, false, false));
+            AddWords(Words("unless"), new IfCommandParameter(true, false, false));
+            AddWords(Words("while"), new IfCommandParameter(false, true, false));
+            AddWords(Words("until"), new IfCommandParameter(true, true, false));
+            AddWords(Words("when"), new IfCommandParameter(true, true, true));
+            AddWords(Words("else", "otherwise"), new ElseCommandParameter());
+            AddWords(Words("that", "with", "which", "whose"), new WithCommandParameter(false));
+            AddWords(Words("without"), new WithCommandParameter(true));
+
+            //Comparison Words
+            AddWords(Words("less", "<", "below"), new ComparisonCommandParameter(ComparisonType.LESS));
+            AddWords(Words("<="), new ComparisonCommandParameter(ComparisonType.LESS_OR_EQUAL));
+            AddWords(Words("is", "are", "equal", "equals", "=", "=="), new ComparisonCommandParameter(ComparisonType.EQUAL));
+            AddWords(Words(">="), new ComparisonCommandParameter(ComparisonType.GREATER_OR_EQUAL));
+            AddWords(Words("greater", ">", "above", "more"), new ComparisonCommandParameter(ComparisonType.GREATER));
+
+            //Aggregation Words
+            AddWords(Words("any"), new AggregationModeCommandParameter(AggregationMode.ANY));
+            AddWords(Words("all", "every", "each"), new AggregationModeCommandParameter(AggregationMode.ALL));
+            AddWords(Words("none"), new AggregationModeCommandParameter(AggregationMode.NONE));
+
+            //Operations Words
+            AddWords(Words("and", "&", "&&", "but", "yet"), new AndCommandParameter());
+            AddWords(Words("or", "|", "||"), new OrCommandParameter());
+            AddWords(Words("not", "!", "isn't", "isnt", "aren't", "arent"), new NotCommandParameter());
+            AddWords(Words("("), new OpenParenthesisCommandParameter());
+            AddWords(Words(")"), new CloseParenthesisCommandParameter());
 
             //Register Special CommandParameter Output Values
             RegisterToString<GroupCommandParameter>(p => "group");
@@ -456,6 +374,10 @@ namespace IngameScript {
                 func = (p) => p.Token;
             }
             return func(parameter).ToString();
+        }
+
+        static String[] Words(params String[] words) {
+            return words;
         }
 
         static void AddWords(String[] words, params CommandParameter[] commands) {
@@ -493,12 +415,8 @@ namespace IngameScript {
                 List<Token> subTokens = ParseTokens(t);
                 List<CommandParameter> subtokenParams = ParseCommandParameters(subTokens);
                 commandParameters.Add(new StringCommandParameter(token.original, subtokenParams.ToArray()));
-            } else if (ignoreWords.Contains(t)) { 
-                //ignore
             } else if (propertyWords.ContainsKey(t)) {
                 commandParameters.AddList(propertyWords[t]);
-            } else if (selfWords.Contains(t)) {
-                commandParameters.Add(new SelfCommandParameter());
             } else if (controlTypeWords.TryGetValue(t, out controlType)) {
                 commandParameters.Add(new ControlCommandParameter(controlType));
             } else if (blockTypeGroupWords.TryGetValue(t, out blockType)) {

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -21,198 +21,6 @@ namespace IngameScript {
     partial class Program {
         static bool Initialized = false;
 
-        static Dictionary<String, UnitType> unitTypeWords = new Dictionary<String, UnitType>()
-        {
-            { "second", UnitType.SECONDS },
-            { "seconds", UnitType.SECONDS },
-            { "tick", UnitType.TICKS },
-            { "ticks", UnitType.TICKS },
-            { "degree", UnitType.DEGREES },
-            { "degrees", UnitType.DEGREES },
-            { "meter", UnitType.METERS },
-            { "meters", UnitType.METERS },
-            { "rpm", UnitType.RPM }
-        };
-
-        static Dictionary<String, UniOperandType> uniOperandWords = new Dictionary<String, UniOperandType> {
-            { "abs", UniOperandType.ABS },
-            { "absolute", UniOperandType.ABS },
-            { "sqrt", UniOperandType.SQRT },
-            { "sin", UniOperandType.SIN },
-            { "cos", UniOperandType.COS },
-            { "tan", UniOperandType.TAN },
-            { "arcsin", UniOperandType.ASIN},
-            { "asin", UniOperandType.ASIN },
-            { "arccos", UniOperandType.ACOS },
-            { "acos", UniOperandType.ACOS },
-            { "arctan", UniOperandType.ATAN },
-            { "atan", UniOperandType.ATAN },
-            { "round", UniOperandType.ROUND },
-        };
-
-        static Dictionary<String, BiOperandType> biOperandWords = new Dictionary<String, BiOperandType> {
-            { "plus", BiOperandType.ADD },
-            { "+", BiOperandType.ADD },
-            { "minus", BiOperandType.SUBTACT },
-            { "-", BiOperandType.SUBTACT },
-            { "multiply", BiOperandType.MULTIPLY },
-            { "*", BiOperandType.MULTIPLY },
-            { "divide", BiOperandType.DIVIDE },
-            { "/", BiOperandType.DIVIDE },
-            { "mod", BiOperandType.MOD },
-            { "%", BiOperandType.MOD },
-            { "dot", BiOperandType.DOT },
-            { ".", BiOperandType.DOT },
-        };
-
-        static Dictionary<String, PropertyAggregatorType> aggregationWords = new Dictionary<String, PropertyAggregatorType> {
-            { "average", PropertyAggregatorType.AVG },
-            { "avg", PropertyAggregatorType.AVG },
-            { "min", PropertyAggregatorType.MIN },
-            { "minimum", PropertyAggregatorType.MIN },
-            { "max", PropertyAggregatorType.MAX },
-            { "maximum", PropertyAggregatorType.MAX},
-            { "count", PropertyAggregatorType.COUNT},
-            { "number", PropertyAggregatorType.COUNT},
-            { "sum", PropertyAggregatorType.SUM},
-            { "total", PropertyAggregatorType.SUM},
-        };
-
-        static Dictionary<String, BlockType> blockTypeGroupWords = new Dictionary<String, BlockType>() {
-            { "pistons", BlockType.PISTON },
-            { "lights", BlockType.LIGHT },
-            { "rotors", BlockType.ROTOR },
-            { "hinges", BlockType.ROTOR },
-            { "programs", BlockType.PROGRAM },
-            { "timers", BlockType.TIMER },
-            { "projectors", BlockType.PROJECTOR },
-            { "connectors", BlockType.CONNECTOR },
-            { "welders", BlockType.WELDER },
-            { "grinders", BlockType.GRINDER },
-            { "doors", BlockType.DOOR },
-            { "hangars", BlockType.DOOR },
-            { "bays", BlockType.DOOR },
-            { "gates", BlockType.DOOR },
-            { "displays", BlockType.DISPLAY },
-            { "screens", BlockType.DISPLAY },
-            { "monitors", BlockType.DISPLAY },
-            { "lcds", BlockType.DISPLAY },
-            { "speakers", BlockType.SOUND },
-            { "alarms", BlockType.SOUND },
-            { "sirens", BlockType.SOUND },
-            { "cameras", BlockType.CAMERA },
-            { "sensors", BlockType.SENSOR },
-            { "beacons", BlockType.BEACON },
-            { "antennae", BlockType.ANTENNA },
-            { "antennas", BlockType.ANTENNA },
-            { "ships", BlockType.COCKPIT },
-            { "rovers", BlockType.COCKPIT },
-            { "cockpits", BlockType.COCKPIT },
-            { "seats", BlockType.COCKPIT },
-            { "drones", BlockType.REMOTE },
-            { "remotes", BlockType.REMOTE },
-            { "robots", BlockType.REMOTE },
-            { "thrusters", BlockType.THRUSTER },
-            { "airvents", BlockType.AIRVENT },
-            { "vents", BlockType.AIRVENT },
-            { "guns", BlockType.GUN },
-            { "rockets", BlockType.GUN },
-            { "missiles", BlockType.GUN },
-            { "launchers", BlockType.GUN },
-            { "turrets", BlockType.TURRET },
-            { "reactors", BlockType.REACTOR },
-            { "generators", BlockType.GENERATOR },
-            { "tanks", BlockType.TANK },
-            { "gears", BlockType.GEAR },
-            { "batteries", BlockType.BATTERY },
-            { "chutes", BlockType.PARACHUTE},
-            { "parachutes", BlockType.PARACHUTE},
-            { "wheels", BlockType.SUSPENSION},
-            { "suspension", BlockType.SUSPENSION},
-            { "detectors", BlockType.DETECTOR},
-            { "drills", BlockType.DRILL},
-            { "engines", BlockType.ENGINE },
-            { "sorters", BlockType.SORTER },
-            { "gyros", BlockType.GYROSCOPE },
-            { "gyroscopes", BlockType.GYROSCOPE },
-            { "gravitygenerators", BlockType.GRAVITY_GENERATOR },
-            { "gravityspheres", BlockType.GRAVITY_SPHERE }
-        };
-
-        static Dictionary<String, BlockType> blockTypeWords = new Dictionary<String, BlockType>() {
-            { "piston", BlockType.PISTON },
-            { "light", BlockType.LIGHT },
-            { "rotor", BlockType.ROTOR },
-            { "hinge", BlockType.ROTOR },
-            { "program", BlockType.PROGRAM },
-            { "timer", BlockType.TIMER },
-            { "projector", BlockType.PROJECTOR },
-            { "merge", BlockType.MERGE },
-            { "connector", BlockType.CONNECTOR },
-            { "welder", BlockType.WELDER },
-            { "grinder", BlockType.GRINDER },
-            { "door", BlockType.DOOR },
-            { "hangar", BlockType.DOOR },
-            { "bay", BlockType.DOOR },
-            { "gate", BlockType.DOOR },
-            { "display", BlockType.DISPLAY },
-            { "screen", BlockType.DISPLAY },
-            { "monitor", BlockType.DISPLAY },
-            { "lcd", BlockType.DISPLAY },
-            { "speaker", BlockType.SOUND },
-            { "alarm", BlockType.SOUND },
-            { "siren", BlockType.SOUND },
-            { "camera", BlockType.CAMERA },
-            { "sensor", BlockType.SENSOR },
-            { "beacon", BlockType.BEACON },
-            { "antenna", BlockType.ANTENNA },
-            { "ship", BlockType.COCKPIT },
-            { "rover", BlockType.COCKPIT },
-            { "cockpit", BlockType.COCKPIT },
-            { "seat", BlockType.COCKPIT },
-            { "drone", BlockType.REMOTE },
-            { "remote", BlockType.REMOTE },
-            { "robot", BlockType.REMOTE },
-            { "thruster", BlockType.THRUSTER },
-            { "airvent", BlockType.AIRVENT },
-            { "vent", BlockType.AIRVENT },
-            { "gun", BlockType.GUN },
-            { "rocket", BlockType.GUN },
-            { "missile", BlockType.GUN },
-            { "launcher", BlockType.GUN },
-            { "turret", BlockType.TURRET },
-            { "reactor", BlockType.REACTOR },
-            { "generator", BlockType.GENERATOR },
-            { "tank", BlockType.TANK },
-            { "gear", BlockType.GEAR },
-            { "battery", BlockType.BATTERY },
-            { "chute", BlockType.PARACHUTE},
-            { "parachute", BlockType.PARACHUTE},
-            { "wheel", BlockType.SUSPENSION},
-            { "detector", BlockType.DETECTOR},
-            { "drill", BlockType.DRILL},
-            { "engine", BlockType.ENGINE },
-            { "sorter", BlockType.SORTER },
-            { "gyro", BlockType.GYROSCOPE },
-            { "gyroscope", BlockType.GYROSCOPE },
-            { "gravitygenerator", BlockType.GRAVITY_GENERATOR },
-            { "gravitysphere", BlockType.GRAVITY_SPHERE }
-        };
-
-        static Dictionary<String, ControlType> controlTypeWords = new Dictionary<string, ControlType>()
-        {
-            { "start", ControlType.START },
-            { "resume", ControlType.START },
-            { "restart", ControlType.RESTART },
-            { "reset", ControlType.RESTART },
-            { "reboot", ControlType.RESTART },
-            { "repeat", ControlType.REPEAT },
-            { "rerun", ControlType.REPEAT },
-            { "replay", ControlType.REPEAT },
-            { "stop", ControlType.STOP },
-            { "pause", ControlType.PAUSE },
-        };
-
         static Dictionary<String, Color> colors = new Dictionary<String, Color>{
             { "red", Color.Red },
             { "blue", Color.Blue },
@@ -258,7 +66,7 @@ namespace IngameScript {
 
             //Value Words
             AddWords(Words("on", "begin", "true"), new BooleanCommandParameter(true));
-            AddWords(Words("off", "terminate", "exit", "cancel", "end", "false"), new BooleanCommandParameter(false));
+            AddWords(Words("off", "terminate", "cancel", "end", "false"), new BooleanCommandParameter(false));
 
             //Property Words
             AddWords(Words("height", "length"), new PropertyCommandParameter(PropertyType.HEIGHT));
@@ -337,13 +145,86 @@ namespace IngameScript {
             AddWords(Words("any"), new AggregationModeCommandParameter(AggregationMode.ANY));
             AddWords(Words("all", "every", "each"), new AggregationModeCommandParameter(AggregationMode.ALL));
             AddWords(Words("none"), new AggregationModeCommandParameter(AggregationMode.NONE));
+            AddWords(Words("average", "avg"), new PropertyAggregationCommandParameter(PropertyAggregatorType.AVG));
+            AddWords(Words("minimum", "min"), new PropertyAggregationCommandParameter(PropertyAggregatorType.MIN));
+            AddWords(Words("maximum", "max"), new PropertyAggregationCommandParameter(PropertyAggregatorType.MAX));
+            AddWords(Words("count", "number"), new PropertyAggregationCommandParameter(PropertyAggregatorType.COUNT));
+            AddWords(Words("sum", "total"), new PropertyAggregationCommandParameter(PropertyAggregatorType.SUM));
 
             //Operations Words
+            AddWords(Words("("), new OpenParenthesisCommandParameter());
+            AddWords(Words(")"), new CloseParenthesisCommandParameter());
             AddWords(Words("and", "&", "&&", "but", "yet"), new AndCommandParameter());
             AddWords(Words("or", "|", "||"), new OrCommandParameter());
             AddWords(Words("not", "!", "isn't", "isnt", "aren't", "arent"), new NotCommandParameter());
-            AddWords(Words("("), new OpenParenthesisCommandParameter());
-            AddWords(Words(")"), new CloseParenthesisCommandParameter());
+            AddWords(Words("absolute", "abs"), new UniOperationCommandParameter(UniOperandType.ABS));
+            AddWords(Words("sqrt"), new UniOperationCommandParameter(UniOperandType.SQRT));
+            AddWords(Words("sin"), new UniOperationCommandParameter(UniOperandType.SIN));
+            AddWords(Words("cosine", "cos"), new UniOperationCommandParameter(UniOperandType.COS));
+            AddWords(Words("tangent", "tan"), new UniOperationCommandParameter(UniOperandType.TAN));
+            AddWords(Words("arcsin", "asin"), new UniOperationCommandParameter(UniOperandType.ASIN));
+            AddWords(Words("arcos", "acos"), new UniOperationCommandParameter(UniOperandType.ACOS));
+            AddWords(Words("arctan", "atan"), new UniOperationCommandParameter(UniOperandType.ATAN));
+            AddWords(Words("round", "rnd"), new UniOperationCommandParameter(UniOperandType.ROUND));
+            AddWords(Words("plus", "+"), new AddCommandParameter(BiOperandType.ADD));
+            AddWords(Words("minus", "-"), new AddCommandParameter(BiOperandType.SUBTACT));
+            AddWords(Words("multiply", "*"), new MultiplyCommandParameter(BiOperandType.MULTIPLY));
+            AddWords(Words("divide", "/"), new MultiplyCommandParameter(BiOperandType.DIVIDE));
+            AddWords(Words("mod", "%"), new MultiplyCommandParameter(BiOperandType.MOD));
+            AddWords(Words("dot", "."), new MultiplyCommandParameter(BiOperandType.DOT));
+
+            //Unit Words
+            AddWords(Words("second", "seconds"), new UnitCommandParameter(UnitType.SECONDS));
+            AddWords(Words("tick", "ticks"), new UnitCommandParameter(UnitType.TICKS));
+            AddWords(Words("degree", "degrees"), new UnitCommandParameter(UnitType.DEGREES));
+            AddWords(Words("meter", "meters"), new UnitCommandParameter(UnitType.METERS));
+            AddWords(Words("rpm"), new UnitCommandParameter(UnitType.RPM));
+
+            //Control Types
+            AddWords(Words("start", "resume"), new ControlCommandParameter(ControlType.START));
+            AddWords(Words("restart", "reset", "reboot"), new ControlCommandParameter(ControlType.RESTART));
+            AddWords(Words("repeat", "loop", "rerun", "replay"), new ControlCommandParameter(ControlType.REPEAT));
+            AddWords(Words("stop", "halt", "exit"), new ControlCommandParameter(ControlType.STOP));
+            AddWords(Words("pause"), new ControlCommandParameter(ControlType.PAUSE));
+
+            //Blocks
+            AddBlockWords(Words("piston"), BlockType.PISTON);
+            AddBlockWords(Words("light"), BlockType.LIGHT);
+            AddBlockWords(Words("rotor", "hinge"), BlockType.ROTOR);
+            AddBlockWords(Words("program"), BlockType.PROGRAM);
+            AddBlockWords(Words("timer"), BlockType.TIMER);
+            AddBlockWords(Words("projector"), BlockType.PROJECTOR);
+            AddBlockWords(Words("merge"), Words(), BlockType.MERGE);
+            AddBlockWords(Words("connector"), BlockType.CONNECTOR);
+            AddBlockWords(Words("welder"), BlockType.WELDER);
+            AddBlockWords(Words("grinder"), BlockType.GRINDER);
+            AddBlockWords(Words("door", "hangar", "bay", "gate"), BlockType.DOOR);
+            AddBlockWords(Words("display", "screen", "lcd"), BlockType.DISPLAY);
+            AddBlockWords(Words("speaker", "alarm", "siren"), BlockType.SOUND);
+            AddBlockWords(Words("camera"), BlockType.CAMERA);
+            AddBlockWords(Words("sensor"), BlockType.SENSOR);
+            AddBlockWords(Words("beacon"), BlockType.BEACON);
+            AddBlockWords(Words("antenna"), BlockType.ANTENNA);
+            AddBlockWords(Words("ship", "rover", "cockpit", "seat"), BlockType.COCKPIT);
+            AddBlockWords(Words("drone", "remote", "robot"), BlockType.REMOTE);
+            AddBlockWords(Words("thruster"), BlockType.THRUSTER);
+            AddBlockWords(Words("airvent", "vent"), BlockType.AIRVENT);
+            AddBlockWords(Words("gun", "rocket", "missile", "launcher"), BlockType.GUN);
+            AddBlockWords(Words("turret"), BlockType.TURRET);
+            AddBlockWords(Words("reactor"), BlockType.REACTOR);
+            AddBlockWords(Words("generator"), BlockType.GENERATOR);
+            AddBlockWords(Words("tank"), BlockType.TANK);
+            AddBlockWords(Words("gear"), BlockType.GEAR);
+            AddBlockWords(Words("battery"), Words("batteries"), BlockType.BATTERY);
+            AddBlockWords(Words("chute", "parachutes"), BlockType.PARACHUTE);
+            AddBlockWords(Words("wheel"), Words("wheels", "suspension"), BlockType.SUSPENSION);
+            AddBlockWords(Words("detector"), BlockType.DETECTOR);
+            AddBlockWords(Words("drill"), BlockType.DRILL);
+            AddBlockWords(Words("engine"), BlockType.ENGINE);
+            AddBlockWords(Words("sorter"), BlockType.SORTER);
+            AddBlockWords(Words("gyro", "gyroscopes"), BlockType.GYROSCOPE);
+            AddBlockWords(Words("gravitygenerator"), BlockType.GRAVITY_GENERATOR);
+            AddBlockWords(Words("gravitysphere"), BlockType.GRAVITY_SPHERE);
 
             //Register Special CommandParameter Output Values
             RegisterToString<GroupCommandParameter>(p => "group");
@@ -380,6 +261,14 @@ namespace IngameScript {
             return words;
         }
 
+        //Assume group words are just blockWords with "s" added to the end
+        static void AddBlockWords(String[] blockWords, BlockType blockType) => AddBlockWords(blockWords, blockWords.Select(b => b + "s").ToArray(), blockType);
+
+        static void AddBlockWords(String[] blockWords, String[] groupWords, BlockType blockType) {
+            AddWords(blockWords, new BlockTypeCommandParameter(blockType));
+            AddWords(groupWords, new BlockTypeCommandParameter(blockType), new GroupCommandParameter());
+        }
+
         static void AddWords(String[] words, params CommandParameter[] commands) {
             foreach (String word in words) propertyWords.Add(word, commands.ToList());
         }
@@ -401,12 +290,6 @@ namespace IngameScript {
         static List<CommandParameter> ParseCommandParameters(Token token) {
             List<CommandParameter> commandParameters = new List<CommandParameter>();
             String t = token.token;
-            ControlType controlType;
-            BlockType blockType;
-            UnitType unitType;
-            UniOperandType uniOperandType;
-            BiOperandType biOperandType;
-            PropertyAggregatorType aggregatorType;
             double numericValue;
 
             if (token.isExplicitString) {
@@ -417,25 +300,6 @@ namespace IngameScript {
                 commandParameters.Add(new StringCommandParameter(token.original, subtokenParams.ToArray()));
             } else if (propertyWords.ContainsKey(t)) {
                 commandParameters.AddList(propertyWords[t]);
-            } else if (controlTypeWords.TryGetValue(t, out controlType)) {
-                commandParameters.Add(new ControlCommandParameter(controlType));
-            } else if (blockTypeGroupWords.TryGetValue(t, out blockType)) {
-                commandParameters.Add(new BlockTypeCommandParameter(blockType));
-                commandParameters.Add(new GroupCommandParameter());
-            } else if (blockTypeWords.TryGetValue(t, out blockType)) {
-                commandParameters.Add(new BlockTypeCommandParameter(blockType));
-            } else if (unitTypeWords.TryGetValue(t, out unitType)) {
-                commandParameters.Add(new UnitCommandParameter(unitType));
-            } else if (uniOperandWords.TryGetValue(t, out uniOperandType)) {
-                commandParameters.Add(new UniOperationCommandParameter(uniOperandType));
-            } else if (biOperandWords.TryGetValue(t, out biOperandType)) {
-                if (biOperandType == BiOperandType.ADD || biOperandType == BiOperandType.SUBTACT) {
-                    commandParameters.Add(new AddCommandParameter(biOperandType));
-                } else {
-                    commandParameters.Add(new MultiplyCommandParameter(biOperandType));
-                }
-            } else if (aggregationWords.TryGetValue(t, out aggregatorType)) {
-                commandParameters.Add(new PropertyAggregationCommandParameter(aggregatorType));
             } else if (Double.TryParse(t, out numericValue)) {
                 commandParameters.Add(new NumericCommandParameter((float)numericValue));
             } else if (t.StartsWith("@")) {

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -19,25 +19,10 @@ using VRageMath;
 
 namespace IngameScript {
     partial class Program {
-        static bool Initialized = false;
-
-        static Dictionary<String, Color> colors = new Dictionary<String, Color>{
-            { "red", Color.Red },
-            { "blue", Color.Blue },
-            { "green", Color.Green },
-            { "orange", Color.Orange },
-            { "yellow", Color.Yellow },
-            { "white", Color.White },
-            { "black", Color.Black}
-        };
-
         //Internal (Don't touch!)
-        private static Dictionary<String, List<CommandParameter>> propertyWords = new Dictionary<string, List<CommandParameter>>();
+        private Dictionary<String, List<CommandParameter>> propertyWords = new Dictionary<string, List<CommandParameter>>();
 
-        public static void InitializeParsers() {
-            //Configuration.  Keep all words lowercase
-            if (Initialized) return;
-
+        public void InitializeParsers() {
             //Ignored words that have no command parameters
             AddWords(Words("the", "than", "turned", "block", "to", "from", "then", "of", "either", "for"));
 
@@ -240,16 +225,15 @@ namespace IngameScript {
             RegisterToString<CommandReferenceParameter>(p => "[Command]");
             RegisterToString<IterationCommandParameter>(p => "[Iteration]");
             RegisterToString<SelectorCommandParameter>(p => "[Selector]");
-            Initialized = true;
         }
 
-        static Dictionary<Type, Func<CommandParameter, object>> commandParameterStrings = new Dictionary<Type, Func<CommandParameter, object>>();
+        Dictionary<Type, Func<CommandParameter, object>> commandParameterStrings = new Dictionary<Type, Func<CommandParameter, object>>();
 
-        static void RegisterToString<T>(Func<T, object> toString) where T : CommandParameter {
+        void RegisterToString<T>(Func<T, object> toString) where T : CommandParameter {
             commandParameterStrings[typeof(T)] = (p) => toString((T)p);
         }
 
-        static string CommandParameterToString(CommandParameter parameter) {
+        string CommandParameterToString(CommandParameter parameter) {
             Func<CommandParameter, object> func;
             if (!commandParameterStrings.TryGetValue(parameter.GetType(), out func)) {
                 func = (p) => p.Token;
@@ -257,24 +241,23 @@ namespace IngameScript {
             return func(parameter).ToString();
         }
 
-        static String[] Words(params String[] words) {
+        String[] Words(params String[] words) {
             return words;
         }
 
         //Assume group words are just blockWords with "s" added to the end
-        static void AddBlockWords(String[] blockWords, BlockType blockType) => AddBlockWords(blockWords, blockWords.Select(b => b + "s").ToArray(), blockType);
+        void AddBlockWords(String[] blockWords, BlockType blockType) => AddBlockWords(blockWords, blockWords.Select(b => b + "s").ToArray(), blockType);
 
-        static void AddBlockWords(String[] blockWords, String[] groupWords, BlockType blockType) {
+        void AddBlockWords(String[] blockWords, String[] groupWords, BlockType blockType) {
             AddWords(blockWords, new BlockTypeCommandParameter(blockType));
             AddWords(groupWords, new BlockTypeCommandParameter(blockType), new GroupCommandParameter());
         }
 
-        static void AddWords(String[] words, params CommandParameter[] commands) {
+        void AddWords(String[] words, params CommandParameter[] commands) {
             foreach (String word in words) propertyWords.Add(word, commands.ToList());
         }
 
-        static List<CommandParameter> ParseCommandParameters(List<Token> tokens) {
-            InitializeParsers();
+        List<CommandParameter> ParseCommandParameters(List<Token> tokens) {
             Trace("Command: " + String.Join(" | ", tokens));
             var parameters = new List<CommandParameter>();
 
@@ -287,7 +270,7 @@ namespace IngameScript {
             return parameters;
         }
 
-        static List<CommandParameter> ParseCommandParameters(Token token) {
+        List<CommandParameter> ParseCommandParameters(Token token) {
             List<CommandParameter> commandParameters = new List<CommandParameter>();
             String t = token.token;
             double numericValue;
@@ -324,7 +307,7 @@ namespace IngameScript {
         }
 
         //Taken shamelessly from https://stackoverflow.com/questions/14655023/split-a-string-that-has-white-spaces-unless-they-are-enclosed-within-quotes
-        public static List<Token> ParseTokens(String commandString) {
+        public List<Token> ParseTokens(String commandString) {
             List<Token> singleQuoteTokens = commandString.Trim().Split('\'')
             .SelectMany((element, index) => index % 2 == 0  // If even index
                 ? ParseDoubleQuotes(element)  // Split the item
@@ -334,7 +317,7 @@ namespace IngameScript {
             return singleQuoteTokens;
         }
 
-        static Token[] ParseDoubleQuotes(String commandString) {
+        Token[] ParseDoubleQuotes(String commandString) {
             return commandString.Trim().Split('"')
                 .Select((element, index) => index % 2 == 0  // If even index
                     ? element.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
@@ -345,7 +328,7 @@ namespace IngameScript {
                 .ToArray();
         }
 
-        static String[] ParseParenthesis(String command) {
+        String[] ParseParenthesis(String command) {
             List<String> tokens = new List<String>();
             if (command.StartsWith("(") || command.StartsWith(")")) {
                 tokens.Add(command.Substring(0, 1));

--- a/EasyCommands/Commands/EntityProviders.cs
+++ b/EasyCommands/Commands/EntityProviders.cs
@@ -94,8 +94,8 @@ namespace IngameScript {
             }
 
             public BlockType ResolveType(String selector, out bool isGroup) {
-                var tokens = ParseTokens(selector);
-                var parameters = ParseCommandParameters(tokens);
+                var tokens = PROGRAM.ParseTokens(selector);
+                var parameters = PROGRAM.ParseCommandParameters(tokens);
                 var blockType = extractFirst<BlockTypeCommandParameter>(parameters);
                 isGroup = extractFirst<GroupCommandParameter>(parameters) != null;
                 if (blockType == null) throw new Exception("Cannot parse block type from selector: " + selector);

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -68,6 +68,16 @@ namespace IngameScript {
             { typeof(Color), PrimitiveType.COLOR }
         };
 
+        static Dictionary<String, Color> colors = new Dictionary<String, Color>{
+            { "red", Color.Red },
+            { "blue", Color.Blue },
+            { "green", Color.Green },
+            { "orange", Color.Orange },
+            { "yellow", Color.Yellow },
+            { "white", Color.White },
+            { "black", Color.Black}
+        };
+
         static PrimitiveType GetType(Type type) {
             PrimitiveType primitiveType;
             if (!PrimitiveTypeMap.TryGetValue(type, out primitiveType)) throw new Exception("No Primitive Type present for type: " + type);
@@ -146,6 +156,7 @@ namespace IngameScript {
         }
 
         public static bool GetColor(String s, out Color color) {
+
             Color? possibleColor = null;
             if (colors.ContainsKey(s.ToLower())) possibleColor = colors[s.ToLower()];
             else if (s.StartsWith("#") && s.Length == 7) {

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -156,7 +156,6 @@ namespace IngameScript {
         }
 
         public static bool GetColor(String s, out Color color) {
-
             Color? possibleColor = null;
             if (colors.ContainsKey(s.ToLower())) possibleColor = colors[s.ToLower()];
             else if (s.StartsWith("#") && s.Length == 7) {

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -23,11 +23,11 @@ namespace IngameScript {
     public partial class Program : MyGridProgram {
         //Debug
         #region mdk preserve
-        public static UpdateFrequency UPDATE_FREQUENCY = UpdateFrequency.Update1;
-        public static LogLevel LOG_LEVEL = LogLevel.INFO;
-        public static int FUNCTION_PARSE_AMOUNT = 1;
-        public static int MAX_ASYNC_THREADS = 50;
-        public static int MAX_QUEUED_THREADS = 50;
+        public UpdateFrequency updateFrequency = UpdateFrequency.Update1;
+        public LogLevel logLevel = LogLevel.INFO;
+        public int functionParseAmount = 1;
+        public int maxAsyncThreads = 50;
+        public int maxQueuedThreads = 50;
         #endregion
 
         public delegate List<MyIGCMessage> BroadcastMessageProvider();
@@ -61,12 +61,12 @@ namespace IngameScript {
 
         public void QueueThread(Thread thread) {
             threadQueue.Add(thread);
-            if (threadQueue.Count > MAX_QUEUED_THREADS) throw new Exception("Stack Overflow Exception! Cannot have more than " + MAX_QUEUED_THREADS + " queued commands");
+            if (threadQueue.Count > maxQueuedThreads) throw new Exception("Stack Overflow Exception! Cannot have more than " + maxQueuedThreads + " queued commands");
         }
 
         public void QueueAsyncThread(Thread thread) {
             asyncThreadQueue.Add(thread);
-            if (asyncThreadQueue.Count > MAX_ASYNC_THREADS) throw new Exception("Stack Overflow Exception! Cannot have more than " + MAX_ASYNC_THREADS + "concurrent async commands");
+            if (asyncThreadQueue.Count > maxAsyncThreads) throw new Exception("Stack Overflow Exception! Cannot have more than " + maxAsyncThreads + "concurrent async commands");
         }
 
         public void SetGlobalVariable(String variableName, Variable variable) {
@@ -96,19 +96,19 @@ namespace IngameScript {
             InitializeParsers();
             InitializeProcessors();
             InitializeOperators();
-            Runtime.UpdateFrequency = UPDATE_FREQUENCY;
+            Runtime.UpdateFrequency = updateFrequency;
             broadcastMessageProvider = provideMessages;
         }
 
         static void Print(String str) { PROGRAM.Echo(str); }
-        static void Info(String str) { if (LOG_LEVEL != LogLevel.SCRIPT_ONLY) PROGRAM.Echo(str); }
-        static void Debug(String str) { if (LOG_LEVEL == LogLevel.DEBUG || LOG_LEVEL == LogLevel.TRACE) PROGRAM.Echo(str); }
-        static void Trace(String str) { if (LOG_LEVEL == LogLevel.TRACE) PROGRAM.Echo(str); }
+        static void Info(String str) { if (PROGRAM.logLevel != LogLevel.SCRIPT_ONLY) PROGRAM.Echo(str); }
+        static void Debug(String str) { if (PROGRAM.logLevel == LogLevel.DEBUG || PROGRAM.logLevel == LogLevel.TRACE) PROGRAM.Echo(str); }
+        static void Trace(String str) { if (PROGRAM.logLevel == LogLevel.TRACE) PROGRAM.Echo(str); }
 
         public void Main(string argument) {
             try {
                 if (!ParseCommands()) {
-                    Runtime.UpdateFrequency = UPDATE_FREQUENCY;
+                    Runtime.UpdateFrequency = updateFrequency;
                     return;
                 }
             } catch (Exception e) {
@@ -189,7 +189,7 @@ namespace IngameScript {
         void UpdateState() {
             switch (state) {
                 case ProgramState.RUNNING:
-                    Runtime.UpdateFrequency = UPDATE_FREQUENCY;
+                    Runtime.UpdateFrequency = updateFrequency;
                     Info("Running");
                     break;
                 case ProgramState.PAUSED:
@@ -257,7 +257,7 @@ namespace IngameScript {
             }
 
             //Parse Function Commands and add to Definitions
-            int toParse = FUNCTION_PARSE_AMOUNT;
+            int toParse = functionParseAmount;
             foreach (int i in functionIndices) {
                 int startingLineNumber = i + 1 + implicitMainOffset;
                 String functionString = commandStrings[i].Remove(0, 1).Trim();


### PR DESCRIPTION
This pull request drastically reduces the character size of ParameterParsers, and removes almost all static references in Program.

The one remaining static reference, arguably the most difficult to remove, is PROGRAM.  This attribute is used in various places across the code, and actually makes the management of many classes easier.  As such, I've decided it's not worth removing this reference, both because it adds more characters to leave it than it does to try and remove it, and because it makes many of the interfaces more cluttered.

As such, this commit should resolve as much of #74 as is reasonable

This set of commits brings the total character count for the program down to 81783