### PR TITLE
Added support for assigning variables using the variable syntax {}

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
@@ -44,6 +44,28 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         }
 
         [TestMethod]
+        public void AssignVariableFromInMemoryVariableName() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign {a} to 2");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("a", assignCommand.variableName);
+            Assert.AreEqual(2, CastNumber(assignCommand.variable.GetValue()).GetNumericValue());
+            Assert.IsFalse(assignCommand.useReference);
+        }
+
+        [TestMethod]
+        public void AssignVariableFromInMemoryVariableSelectorName() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign [a] to 2");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("a", assignCommand.variableName);
+            Assert.AreEqual(2, CastNumber(assignCommand.variable.GetValue()).GetNumericValue());
+            Assert.IsFalse(assignCommand.useReference);
+        }
+
+        [TestMethod]
         public void AssignVariableCaseIsPreserved() {
             var program = MDKFactory.CreateProgram<Program>();
             var command = program.ParseCommand("assign \"a\" to {variableName}");

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -45,6 +45,13 @@ namespace IngameScript {
             TwoValueRule<AssignmentCommandParameter,GlobalCommandParameter,ExplicitStringCommandParameter>(
                 optionalRight<GlobalCommandParameter>(), requiredRight<ExplicitStringCommandParameter>(),
                 (p,g,name) => new VariableAssignmentCommandParameter(name.GetValue().value, p.useReference, g.HasValue())),
+            TwoValueRule<AssignmentCommandParameter,GlobalCommandParameter,VariableCommandParameter>(
+                optionalRight<GlobalCommandParameter>(), requiredRight<VariableCommandParameter>(),
+                (p,g,name) => name.HasValue() && name.GetValue().value is InMemoryVariable,
+                (p,g,name) => new VariableAssignmentCommandParameter(((InMemoryVariable)name.GetValue().value).variableName, p.useReference, g.HasValue())),
+            TwoValueRule<AssignmentCommandParameter,GlobalCommandParameter,VariableSelectorCommandParameter>(
+                optionalRight<GlobalCommandParameter>(), requiredRight<VariableSelectorCommandParameter>(),
+                (p,g,name) => new VariableAssignmentCommandParameter(((InMemoryVariable)name.GetValue().value).variableName, p.useReference, g.HasValue())),
 
             //SelfSelectorProcessor
             OneValueRule<SelfCommandParameter,BlockTypeCommandParameter>(


### PR DESCRIPTION
I've seen a few times (and done this myself) where a user tries to say:

"assign {a} to {b}" since normally you use {} or []to interact with a variable.

Currently you have to do either:
assign "a" to {b}
assign 'a' to {b}

Now you can also do
assign {a} to {b}
assign [a] to {b}
