### PR TITLE
Added Implicit String Variable Support

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -148,6 +148,7 @@
     <Compile Include="ScriptTests\RotorControlTests.cs" />
     <Compile Include="ScriptTests\AirLockManagerTests.cs" />
     <Compile Include="ScriptTests\GravityBlockTests.cs" />
+    <Compile Include="ScriptTests\SimpleVariableTests.cs" />
     <Compile Include="TokenParsingTests\StringParsingTests.cs" />
     <Compile Include="TokenParsingTests\ParenthesisParsingTests.cs" />
     <Compile Include="Util\Extensions.cs" />

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
@@ -44,6 +44,30 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         }
 
         [TestMethod]
+        public void AssignVariableToAmbiguousStringValue() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to b");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("a", assignCommand.variableName);
+            Assert.AreEqual("b", assignCommand.variable.GetValue().GetValue());
+            Assert.IsFalse(assignCommand.useReference);
+        }
+
+        [TestMethod]
+        public void AssignVariableToImplicitVariableReference() {
+            var program = MDKFactory.CreateProgram<Program>();
+            program.QueueThread(new Thread(new NullCommand(), "test", "test"));
+            program.SetGlobalVariable("b", new StaticVariable(new NumberPrimitive(4)));
+            var command = program.ParseCommand("assign a to b");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("a", assignCommand.variableName);
+            Assert.AreEqual(4, CastNumber(assignCommand.variable.GetValue()).GetNumericValue());
+            Assert.IsFalse(assignCommand.useReference);
+        }
+
+        [TestMethod]
         public void AssignVariableCaseIsPreserved() {
             var program = MDKFactory.CreateProgram<Program>();
             var command = program.ParseCommand("assign \"a\" to {variableName}");

--- a/EasyCommands.Tests/ScriptTests/RocketVolleyTests.cs
+++ b/EasyCommands.Tests/ScriptTests/RocketVolleyTests.cs
@@ -25,7 +25,7 @@ assign global ""i"" to 0
 
 :startFiring
 assign global ""firing"" to true
-assign global ""i"" to 0
+assign global i to 0
 
 :stopFiring
 tell [rocketGroup] rockets to not shoot
@@ -33,13 +33,13 @@ assign global ""firing"" to false
 
 :fireLoop
 if not {firing} replay
-print ""i = "" + {i}
+print ""i = "" + i
 if {i} >= count of [rocketGroup] rockets
-  assign global ""i"" to 0
-tell [rocketGroup] rockets @ {i} to shoot
+  assign global i to 0
+tell [rocketGroup] rockets @ i to shoot
 tell [rocketGroup] rockets to not shoot
 wait {fireTickInterval} ticks
-assign global ""i"" to {i} + 1
+assign global i to i + 1
 goto ""fireLoop""
 ";
             using (var test = new ScriptTest(script)) {

--- a/EasyCommands.Tests/ScriptTests/SimpleVariableTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleVariableTests.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using IngameScript;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class SimpleVariableTests {
+        [TestMethod]
+        public void TestImplicitVariableAssignmentAndGetValue() {
+            var script = @"
+assign a to 1
+assign b to a + 1
+Print ""b is: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.program.logLevel = Program.LogLevel.INFO;
+
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("b is: 2"));
+            }
+        }
+
+        [TestMethod]
+        public void TestImplicitStringValue() {
+            var script = @"
+assign b to a + 1
+Print ""b is: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.program.logLevel = Program.LogLevel.INFO;
+
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("b is: a1"));
+            }
+        }
+    }
+}

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -280,7 +280,7 @@ namespace IngameScript {
             } else if (token.isString) {
                 List<Token> subTokens = ParseTokens(t);
                 List<CommandParameter> subtokenParams = ParseCommandParameters(subTokens);
-                commandParameters.Add(new StringCommandParameter(token.original, subtokenParams.ToArray()));
+                commandParameters.Add(new StringCommandParameter(token.original, false, subtokenParams.ToArray()));
             } else if (propertyWords.ContainsKey(t)) {
                 commandParameters.AddList(propertyWords[t]);
             } else if (Double.TryParse(t, out numericValue)) {
@@ -300,7 +300,7 @@ namespace IngameScript {
             } else if (t.StartsWith("[") && t.EndsWith("]")) { //Variable References used as Selectors
                 commandParameters.Add(new VariableSelectorCommandParameter(new InMemoryVariable(token.original.Substring(1, token.original.Length - 2))));
             } else { //If nothing else matches, must be a string
-                commandParameters.Add(new StringCommandParameter(token.original));
+                commandParameters.Add(new StringCommandParameter(token.original, true));
             }
 
             return commandParameters;

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -65,7 +65,7 @@ namespace IngameScript {
                         return blockType.HasValue();
                         },
                         (p,blockType,group) => new SelectorCommandParameter(new SelectorEntityProvider(blockType.GetValue().value, group.HasValue(), new StaticVariable(new StringPrimitive(p.value))))),
-                NoValueRule<StringCommandParameter>(p => new ExplicitStringCommandParameter(p.value))),
+                new PrimitiveProcessor<StringCommandParameter>()),
 
             //VariableSelectorProcessor
             TwoValueRule<VariableSelectorCommandParameter,BlockTypeCommandParameter,GroupCommandParameter>(
@@ -73,7 +73,7 @@ namespace IngameScript {
                 (p,blockType,group) => new SelectorCommandParameter(new SelectorEntityProvider(blockType.HasValue() ? blockType.GetValue().value : (Block?)null, group.HasValue(), p.value))),
 
             //Primitive Procesor
-            new PrimitiveProcessor(),
+            new PrimitiveProcessor<PrimitiveCommandParameter>(),
 
             //RedundantComparisonProcessor
             //"is not <" => "!<"
@@ -538,14 +538,14 @@ namespace IngameScript {
             }
         }
 
-        public class PrimitiveProcessor : ParameterProcessor<PrimitiveCommandParameter> {
+        public class PrimitiveProcessor<T> : ParameterProcessor<T> where T : class, PrimitiveCommandParameter {
             public override List<Type> GetProcessedTypes() {
                 return new List<Type>() { typeof(StringCommandParameter), typeof(NumericCommandParameter), typeof(BooleanCommandParameter), typeof(ExplicitStringCommandParameter) };
             }
 
             public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters, List<List<CommandParameter>> branches) {
                 if (p[i] is ValueCommandParameter<String>) {
-                    p[i] = GetParameter(((ValueCommandParameter<String>)p[i]).value);
+                    p[i] = GetParameter(((ValueCommandParameter<String>)p[i]).value, p[i] is ExplicitStringCommandParameter);
                 } else if (p[i] is NumericCommandParameter) {
                     p[i] = new VariableCommandParameter(new StaticVariable(new NumberPrimitive(((NumericCommandParameter)p[i]).value)));
                 } else if (p[i] is BooleanCommandParameter) {
@@ -558,13 +558,17 @@ namespace IngameScript {
                 return true;
             }
 
-            VariableCommandParameter GetParameter(String value) {
-                Primitive primitive = new StringPrimitive(value);
+            VariableCommandParameter GetParameter(String value, bool isExplicit) {
+                Primitive primitive = null;
                 Vector3D vector;
                 if (GetVector(value, out vector)) primitive = new VectorPrimitive(vector);
                 Color color;
                 if (GetColor(value, out color)) primitive = new ColorPrimitive(color);
-                return new VariableCommandParameter(new StaticVariable(primitive));
+
+                Variable variable = new AmbiguousStringVariable(value);
+
+                if (primitive != null || isExplicit) variable = new StaticVariable(primitive ?? new StringPrimitive(value));
+                return new VariableCommandParameter(variable);
             }
         }
 

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -140,8 +140,10 @@ namespace IngameScript {
 
         public class StringCommandParameter : ValueCommandParameter<String>, PrimitiveCommandParameter {
             public List<CommandParameter> SubTokens = new List<CommandParameter>();
-            public StringCommandParameter(String value, params CommandParameter[] SubTokens) : base(value) {
+            public bool isImplicit;
+            public StringCommandParameter(String value, bool isImplicit, params CommandParameter[] SubTokens) : base(value) {
                 this.SubTokens = SubTokens.ToList();
+                this.isImplicit = isImplicit;
             }
         }
 

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -170,6 +170,22 @@ namespace IngameScript {
             }
         }
 
+        public class AmbiguousStringVariable : Variable {
+            public String value;
+
+            public AmbiguousStringVariable(String value) {
+                this.value = value;
+            }
+
+            public Primitive GetValue() {
+                try {
+                    return PROGRAM.GetVariable(value).GetValue();
+                } catch(Exception) {
+                    return new StringPrimitive(value);
+                }
+            }
+        }
+
         public class InMemoryVariable : Variable {
             public String variableName;
 


### PR DESCRIPTION
This commit removes the need to wrap variable references with {a}.  Now, by default, ambiguous strings will be checked against the current variables before being
assumed to be string values.

Before this commit you'd have to do something like this:




```
assign "i" to 0
Print "Value of i is: " + {i}
```


Now you can do:
```
assign "i" to 0
Print "Value of i is: " + i
```



