### PR TITLE
Added Color Parsing From Vector Support

### DIFF
--- a/EasyCommands.Tests/ScriptTests/LightBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/LightBlockTests.cs
@@ -44,6 +44,23 @@ turn on the ""cool light""
         }
 
         [TestMethod]
+        public void SetLightBlockColorFromVector() {
+            String script = @"
+:lightshow
+set the ""cool light"" color to ""255:128:0""
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockLight = new Mock<IMyLightingBlock>();
+                test.MockBlocksOfType("cool light", mockLight);
+
+                test.RunUntilDone();
+
+                mockLight.VerifySet(b => b.Color = new Color(255, 128, 0));
+            }
+        }
+
+        [TestMethod]
         public void MultipleBlocksSameType()
         {
             String script = @"

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -151,6 +151,9 @@ namespace IngameScript {
                     goto default;
                 case Return.NUMERIC:
                     return new ColorPrimitive(new Color((float)p.GetValue()));
+                case Return.VECTOR:
+                    var vector = CastVector(p).GetVectorValue();
+                    return new ColorPrimitive(new Color((int)vector.X, (int)vector.Y, (int)vector.Z));
                 default: throw new Exception("Cannot convert Primitive type: " + p.GetPrimitiveType() + " to Color");
             }
         }


### PR DESCRIPTION
This commit adds some simple support for parsing a color from a vector, using X as red, Y as green, and Z as blue

Implements #81 