### PR TITLE
Dictionary support enhancement

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/ListParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/ListParameterProcessorTests.cs
@@ -21,7 +21,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             ListIndexVariable listIndex = (ListIndexVariable)assignmentCommand.variable;
             Primitive list = listIndex.expectedList.GetValue();
             Assert.AreEqual(Return.LIST, list.GetPrimitiveType());
-            List<Variable> listItems = CastList(list).GetTypedValue();
+            List<Variable> listItems = CastList(list).GetTypedValue().GetValues();
             Assert.AreEqual(3, listItems.Count);
             Assert.AreEqual("one", CastString(listItems[0].GetValue()).GetTypedValue());
             Assert.AreEqual("two", CastString(listItems[1].GetValue()).GetTypedValue());
@@ -54,7 +54,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.AreEqual(0, CastNumber(assignmentCommand.list.index.GetValue()).GetTypedValue());
             Primitive list = assignmentCommand.value.GetValue();
             Assert.AreEqual(Return.LIST, list.GetPrimitiveType());
-            List<Variable> listItems = CastList(list).GetTypedValue();
+            List<Variable> listItems = CastList(list).GetTypedValue().GetValues();
             Assert.AreEqual(3, listItems.Count);
             Assert.AreEqual("one", CastString(listItems[0].GetValue()).GetTypedValue());
             Assert.AreEqual("two", CastString(listItems[1].GetValue()).GetTypedValue());
@@ -70,7 +70,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.IsTrue(assignmentCommand.list.expectedList is InMemoryVariable);
             InMemoryVariable listName = (InMemoryVariable)assignmentCommand.list.expectedList;
             Assert.AreEqual("myList", listName.variableName);
-            List<Variable> listIndexes = CastList(assignmentCommand.list.index.GetValue()).GetTypedValue();
+            List<Variable> listIndexes = CastList(assignmentCommand.list.index.GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(4, listIndexes.Count);
             Assert.AreEqual(0, CastNumber(listIndexes[0].GetValue()).GetTypedValue());
             Assert.AreEqual(1, CastNumber(listIndexes[1].GetValue()).GetTypedValue());
@@ -97,7 +97,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
             Assert.AreEqual("myValue", assignmentCommand.variableName);
-            List<Variable> values = CastList(assignmentCommand.variable.GetValue()).GetTypedValue();
+            List<Variable> values = CastList(assignmentCommand.variable.GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(3, values.Count);
             Assert.AreEqual(5f, CastNumber(values[0].GetValue()).GetTypedValue());
             Assert.AreEqual(6f, CastNumber(values[1].GetValue()).GetTypedValue());
@@ -113,12 +113,12 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.IsTrue(assignmentCommand.list.expectedList is InMemoryVariable);
             InMemoryVariable listName = (InMemoryVariable)assignmentCommand.list.expectedList;
             Assert.AreEqual("myList", listName.variableName);
-            List<Variable> listIndexes = CastList(assignmentCommand.list.index.GetValue()).GetTypedValue();
+            List<Variable> listIndexes = CastList(assignmentCommand.list.index.GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(3, listIndexes.Count);
             Assert.AreEqual(1, CastNumber(listIndexes[0].GetValue()).GetTypedValue());
             Assert.AreEqual(2, CastNumber(listIndexes[1].GetValue()).GetTypedValue());
             Assert.AreEqual(3, CastNumber(listIndexes[2].GetValue()).GetTypedValue());
-            List<Variable> assignedValue = CastList(assignmentCommand.value.GetValue()).GetTypedValue();
+            List<Variable> assignedValue = CastList(assignmentCommand.value.GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(1, assignedValue.Count);
             Assert.AreEqual(0f, assignedValue[0].GetValue().GetValue());
         }
@@ -130,15 +130,15 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
             Assert.AreEqual("myList", assignmentCommand.variableName);
-            List<Variable> values = CastList(assignmentCommand.variable.GetValue()).GetTypedValue();
+            List<Variable> values = CastList(assignmentCommand.variable.GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(2, values.Count);
 
-            List<Variable> myList0 = CastList(values[0].GetValue()).GetTypedValue();
+            List<Variable> myList0 = CastList(values[0].GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(0f, CastNumber(myList0[0].GetValue()).GetTypedValue());
             Assert.AreEqual(1f, CastNumber(myList0[1].GetValue()).GetTypedValue());
             Assert.AreEqual(2f, CastNumber(myList0[2].GetValue()).GetTypedValue());
 
-            List<Variable> myList1 = CastList(values[1].GetValue()).GetTypedValue();
+            List<Variable> myList1 = CastList(values[1].GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(3f, CastNumber(myList1[0].GetValue()).GetTypedValue());
             Assert.AreEqual(4f, CastNumber(myList1[1].GetValue()).GetTypedValue());
             Assert.AreEqual(5f, CastNumber(myList1[2].GetValue()).GetTypedValue());
@@ -161,7 +161,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
             Assert.AreEqual("myValue", assignmentCommand.variableName);
-            List<Variable> listValues = CastList(assignmentCommand.variable.GetValue()).GetTypedValue();
+            List<Variable> listValues = CastList(assignmentCommand.variable.GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(3, listValues.Count);
             Assert.AreEqual(3f, listValues[0].GetValue().GetValue());
             Assert.AreEqual(4f, listValues[1].GetValue().GetValue());

--- a/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
@@ -478,7 +478,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             var command = program.ParseCommand("assign a to [0, 1, 2] + 3");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
-            List<Variable> listValues = CastList(assignment.variable.GetValue()).GetTypedValue();
+            List<Variable> listValues = CastList(assignment.variable.GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(4, listValues.Count);
             Assert.AreEqual(0f, listValues[0].GetValue().GetValue());
             Assert.AreEqual(1f, listValues[1].GetValue().GetValue());
@@ -492,7 +492,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             var command = program.ParseCommand("assign a to 0 + [1, 2, 3]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
-            List<Variable> listValues = CastList(assignment.variable.GetValue()).GetTypedValue();
+            List<Variable> listValues = CastList(assignment.variable.GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(4, listValues.Count);
             Assert.AreEqual(0f, listValues[0].GetValue().GetValue());
             Assert.AreEqual(1f, listValues[1].GetValue().GetValue());
@@ -524,7 +524,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             var command = program.ParseCommand("assign a to [0, 1, 2] + [3, 4, 5]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
-            List<Variable> listValues = CastList(assignment.variable.GetValue()).GetTypedValue();
+            List<Variable> listValues = CastList(assignment.variable.GetValue()).GetTypedValue().GetValues();
             Assert.AreEqual(6, listValues.Count);
             Assert.AreEqual(0f, listValues[0].GetValue().GetValue());
             Assert.AreEqual(1f, listValues[1].GetValue().GetValue());

--- a/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
@@ -345,6 +345,61 @@ Print ""After: "" + myList
         }
 
         [TestMethod]
+        public void RemoveFromListByIndexes() {
+            String script = @"
+:main
+assign myList to [1,2,3,4,5,6]
+Print ""Before: "" + myList
+assign myList to myList - [0,2,4]
+Print ""After: "" + myList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: [1,2,3,4,5,6]"));
+                Assert.IsTrue(test.Logger.Contains("After: [2,4,6]"));
+            }
+        }
+
+        [TestMethod]
+        public void RemoveFromListByKey() {
+            String script = @"
+:main
+assign myList to []
+assign myList[""key1""] to ""value1""
+assign myList[""key2""] to ""value2""
+Print ""Before: "" + myList
+assign myList to myList - [""key1""]
+Print ""After: "" + myList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: [key1=value1,key2=value2]"));
+                Assert.IsTrue(test.Logger.Contains("After: [key2=value2]"));
+            }
+        }
+
+        [TestMethod]
+        public void RemoveFromListByIndexesAndKeys() {
+            String script = @"
+:main
+assign myList to [1,2,3,4,5,6]
+assign myList[""key1""] to ""value1""
+assign myList[""key2""] to ""value2""
+Print ""Before: "" + myList
+assign myList to myList - [0,2,4,""key1"",""key3""]
+Print ""After: "" + myList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: [1,2,3,4,5,6,key1=value1,key2=value2]"));
+                Assert.IsTrue(test.Logger.Contains("After: [2,4,6,key2=value2]"));
+            }
+        }
+
+        [TestMethod]
         public void AddTwoKeyedListsDedupesKeysAndUsesSecondValue() {
             String script = @"
 :main

--- a/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
@@ -115,6 +115,76 @@ Print ""After: "" + myList
         }
 
         [TestMethod]
+        public void AssignListKeyValue() {
+            String script = @"
+:main
+assign myList to []
+Print ""Before: "" + myList
+assign myList[""key""] to ""value""
+Print ""After: "" + myList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: []"));
+                Assert.IsTrue(test.Logger.Contains("After: [key=value]"));
+            }
+        }
+
+        [TestMethod]
+        public void UpdateListKeyValue() {
+            String script = @"
+:main
+assign myList to []
+assign myList[""key""] to ""value""
+Print ""Before: "" + myList
+assign myList[""key""] to ""newValue""
+Print ""After: "" + myList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: [key=value]"));
+                Assert.IsTrue(test.Logger.Contains("After: [key=newValue]"));
+            }
+        }
+
+        [TestMethod]
+        public void AddKeyValueToNonKeyedListAddsToEnd() {
+            String script = @"
+:main
+assign myList to [1,2,3]
+Print ""Before: "" + myList
+assign myList[""key""] to ""value""
+Print ""After: "" + myList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: [1,2,3]"));
+                Assert.IsTrue(test.Logger.Contains("After: [1,2,3,key=value]"));
+            }
+        }
+
+        [TestMethod]
+        public void GetItemInListByKeyedValue() {
+            String script = @"
+:main
+assign myList to []
+assign myKey to ""key""
+assign myList[myKey] to ""value""
+Print ""myList["" + myKey + ""] = "" + myList[myKey]
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("myList[key] = value"));
+            }
+        }
+
+        //TODO Add methods for getting keys, iterating over keys, getting values.
+
+        [TestMethod]
         public void AssignListSubRangeNewValue() {
             String script = @"
 :main

--- a/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
@@ -182,7 +182,49 @@ Print ""myList["" + myKey + ""] = "" + myList[myKey]
             }
         }
 
-        //TODO Add methods for getting keys, iterating over keys, getting values.
+        [TestMethod]
+        public void GetListKeys() {
+            String script = @"
+:main
+assign myList to []
+assign myList[""key1""] to ""value""
+assign myList[""key2""] to ""value""
+assign myKeys to myList keys
+Print ""Keys: "" + myKeys
+Print ""Size of Keys: "" + count of myKeys[]
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Keys: [key1,key2]"));
+                Assert.IsTrue(test.Logger.Contains("Size of Keys: 2"));
+            }
+        }
+
+        [TestMethod]
+        public void IterateOverListByKeys() {
+            String script = @"
+:main
+assign myList to [1,2,3]
+assign myList[""key1""] to ""value1""
+assign myList[""key2""] to ""value2""
+assign myKeys to myList keys
+Print ""Keys: "" + myKeys
+assign i to 0
+until i >= count of myKeys[]
+  Print ""myList["" + myKeys[i] + ""] = "" + myList[myKeys[i]]
+  assign i to i + 1
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.IsTrue(test.Logger.Contains("Keys: [key1,key2]"));
+                Assert.IsTrue(test.Logger.Contains("myList[key1] = value1"));
+                Assert.IsTrue(test.Logger.Contains("myList[key2] = value2"));
+            }
+        }
+
+        //TODO: Add tests combining keyed lists, make sure merge on key values works
 
         [TestMethod]
         public void AssignListSubRangeNewValue() {

--- a/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
@@ -203,7 +203,7 @@ Print ""Values: "" + myList[""key1"",""key2""]
         public void GetListKeys() {
             String script = @"
 :main
-assign myList to []
+assign myList to [1,2,3]
 assign myList[""key1""] to ""value""
 assign myList[""key2""] to ""value""
 assign myKeys to myList keys
@@ -218,7 +218,24 @@ Print ""Size of Keys: "" + count of myKeys[]
             }
         }
 
-        //TODO: Add GetListValues()
+        [TestMethod]
+        public void GetListValues() {
+            String script = @"
+:main
+assign myList to [1,2,3]
+assign myList[""key1""] to ""value1""
+assign myList[""key2""] to ""value2""
+assign myValues to myList values
+Print ""Values: "" + myValues
+Print ""Size of Values: "" + count of myValues[]
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Values: [1,2,3,value1,value2]"));
+                Assert.IsTrue(test.Logger.Contains("Size of Values: 5"));
+            }
+        }
 
         [TestMethod]
         public void IterateOverListByKeys() {

--- a/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
@@ -183,6 +183,21 @@ Print ""myList["" + myKey + ""] = "" + myList[myKey]
         }
 
         [TestMethod]
+        public void GetNonExistentValueByKeyReturnsEmptyList() {
+            String script = @"
+:main
+assign myList to []
+assign myList[""key""] to ""value""
+Print ""myList[missingKey] = "" + myList[""missingKey""]
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("myList[missingKey] = []"));
+            }
+        }
+
+        [TestMethod]
         public void GetSubListFromKeyedList() {
             String script = @"
 :main

--- a/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
@@ -381,6 +381,27 @@ Print ""After: "" + myList
         }
 
         [TestMethod]
+        public void RemoveFromBoundListByKey() {
+            String script = @"
+:main
+assign myList to []
+assign i to ""oldValue""
+assign myList[""key1""] to ""value1""
+bind myList[""key2""] to i
+Print ""Before: "" + myList
+bind subList to myList - [""key1""]
+assign i to ""newValue""
+Print ""After: "" + subList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: [key1=value1,key2=oldValue]"));
+                Assert.IsTrue(test.Logger.Contains("After: [key2=newValue]"));
+            }
+        }
+
+        [TestMethod]
         public void RemoveFromListByIndexesAndKeys() {
             String script = @"
 :main

--- a/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
@@ -183,6 +183,23 @@ Print ""myList["" + myKey + ""] = "" + myList[myKey]
         }
 
         [TestMethod]
+        public void GetSubListFromKeyedList() {
+            String script = @"
+:main
+assign myList to []
+assign myList[""key1""] to ""value1""
+assign myList[""key2""] to ""value2""
+assign myList[""key3""] to ""value3""
+Print ""Values: "" + myList[""key1"",""key2""]
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Values: [key1=value1,key2=value2]"));
+            }
+        }
+
+        [TestMethod]
         public void GetListKeys() {
             String script = @"
 :main
@@ -200,6 +217,8 @@ Print ""Size of Keys: "" + count of myKeys[]
                 Assert.IsTrue(test.Logger.Contains("Size of Keys: 2"));
             }
         }
+
+        //TODO: Add GetListValues()
 
         [TestMethod]
         public void IterateOverListByKeys() {
@@ -223,8 +242,6 @@ until i >= count of myKeys[]
                 Assert.IsTrue(test.Logger.Contains("myList[key2] = value2"));
             }
         }
-
-        //TODO: Add tests combining keyed lists, make sure merge on key values works
 
         [TestMethod]
         public void AssignListSubRangeNewValue() {
@@ -274,6 +291,47 @@ Print ""After: "" + myList
 
                 Assert.IsTrue(test.Logger.Contains("Before: [1,2,3,4]"));
                 Assert.IsTrue(test.Logger.Contains("After: [1,2,3,4,5]"));
+            }
+        }
+
+        [TestMethod]
+        public void AddTwoLists() {
+            String script = @"
+:main
+assign myList to [1,2,3]
+assign myList2 to [4,5,6]
+Print ""Before: "" + myList
+assign myList to myList + myList2
+Print ""After: "" + myList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: [1,2,3]"));
+                Assert.IsTrue(test.Logger.Contains("After: [1,2,3,4,5,6]"));
+            }
+        }
+
+        [TestMethod]
+        public void AddTwoKeyedListsDedupesKeysAndUsesSecondValue() {
+            String script = @"
+:main
+assign myKey to ""key""
+assign myList to []
+assign myList[myKey] to ""oldValue""
+assign myList[""key1""] to ""value1""
+assign myList2 to []
+assign myList2[myKey] to ""newValue""
+assign myList2[""key2""] to ""value2""
+Print ""Before: "" + myList
+assign myList to myList + myList2
+Print ""After: "" + myList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: [key=oldValue,key1=value1]"));
+                Assert.IsTrue(test.Logger.Contains("After: [key1=value1,key=newValue,key2=value2]"));
             }
         }
 

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -158,6 +158,7 @@ namespace IngameScript {
             AddWords(Words("arcos", "acos"), new UniOperationCommandParameter(UniOperand.ACOS));
             AddWords(Words("arctan", "atan"), new UniOperationCommandParameter(UniOperand.ATAN));
             AddWords(Words("round", "rnd"), new UniOperationCommandParameter(UniOperand.ROUND));
+            AddWords(Words("keys"), new LeftUniOperationCommandParameter(UniOperand.KEYS));
             AddWords(Words("multiply", "*"), new BiOperandTier1Operand(BiOperand.MULTIPLY));
             AddWords(Words("divide", "/"), new BiOperandTier1Operand(BiOperand.DIVIDE));
             AddWords(Words("mod", "%"), new BiOperandTier1Operand(BiOperand.MOD));

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -158,7 +158,8 @@ namespace IngameScript {
             AddWords(Words("arcos", "acos"), new UniOperationCommandParameter(UniOperand.ACOS));
             AddWords(Words("arctan", "atan"), new UniOperationCommandParameter(UniOperand.ATAN));
             AddWords(Words("round", "rnd"), new UniOperationCommandParameter(UniOperand.ROUND));
-            AddWords(Words("keys"), new LeftUniOperationCommandParameter(UniOperand.KEYS));
+            AddWords(Words("keys", "indexes"), new LeftUniOperationCommandParameter(UniOperand.KEYS));
+            AddWords(Words("values"), new LeftUniOperationCommandParameter(UniOperand.VALUES));
             AddWords(Words("multiply", "*"), new BiOperandTier1Operand(BiOperand.MULTIPLY));
             AddWords(Words("divide", "/"), new BiOperandTier1Operand(BiOperand.DIVIDE));
             AddWords(Words("mod", "%"), new BiOperandTier1Operand(BiOperand.MOD));

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -128,6 +128,11 @@ namespace IngameScript {
                 requiredRight<VariableCommandParameter>(),
                 (p,df) => new VariableCommandParameter(new UniOperandVariable(p.value, df.GetValue().value))),
 
+            //AfterUniOperationProcessor
+            OneValueRule<LeftUniOperationCommandParameter,VariableCommandParameter>(
+                requiredLeft<VariableCommandParameter>(),
+                (p,df) => new VariableCommandParameter(new UniOperandVariable(p.value, df.GetValue().value))),
+
             //Tier1OperationProcessor
             TwoValueRule<BiOperandTier1Operand,VariableCommandParameter,VariableCommandParameter>(
                 requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -33,7 +33,7 @@ namespace IngameScript {
                     requiredLeft<ListIndexCommandParameter>(),
                     (list, index) => new ListIndexCommandParameter(new ListIndexVariable(index.GetValue().value, list.value))),
                 NoValueRule<ListCommandParameter>(
-                    (list) => new ListIndexCommandParameter(new ListIndexVariable(list.value, GetVariables(new List<Variable>())[0])))),
+                    (list) => new ListIndexCommandParameter(new ListIndexVariable(list.value, GetVariables(new KeyedList())[0])))),
 
             new IgnoreProcessor(),
 
@@ -622,7 +622,7 @@ namespace IngameScript {
                     }
                     else if (p[j] is CloseBracketCommandParameter) {
                         if (j > i + 1) indexValues.Add(ParseVariable(p, startIndex, j)); //dont try to parse []
-                        finalParameters = new List<CommandParameter> { new ListCommandParameter(indexValues.Count() == 1 ?  indexValues[0] : GetStaticVariable(indexValues)) };
+                        finalParameters = new List<CommandParameter> { new ListCommandParameter(indexValues.Count() == 1 ?  indexValues[0] : GetStaticVariable(new KeyedList(indexValues.ToArray()))) };
                         p.RemoveRange(i, j - i + 1);
                         p.InsertRange(i, finalParameters);
                         return true;

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -71,6 +71,11 @@ namespace IngameScript {
             }
         }
 
+        public class LeftUniOperationCommandParameter : ValueCommandParameter<UniOperand> {
+            public LeftUniOperationCommandParameter(UniOperand value) : base(value) {
+            }
+        }
+
         public class BiOperandTier1Operand : ValueCommandParameter<BiOperand> {
             public BiOperandTier1Operand(BiOperand value) : base(value) {}
         }

--- a/EasyCommands/Common/Collections.cs
+++ b/EasyCommands/Common/Collections.cs
@@ -62,6 +62,10 @@ namespace IngameScript {
                 return new KeyedList(GetValues().Concat(other.GetValues()).ToArray());
             }
 
+            public KeyedList Keys() {
+                return new KeyedList(keyedValues.Where(v => !string.IsNullOrEmpty(v.Key)).Select(v => GetStaticVariable(v.Key)).ToArray());
+            }
+
             public String Print() {
                 return "[" + string.Join(",", keyedValues.Select(k => (string.IsNullOrEmpty(k.Key) ? "" : k.Key + "=") + CastString(k.Value.GetValue()).GetTypedValue())) + "]";
             }

--- a/EasyCommands/Common/Collections.cs
+++ b/EasyCommands/Common/Collections.cs
@@ -63,6 +63,12 @@ namespace IngameScript {
                 return new KeyedList(uniqueKeyedVariables.Concat(other.GetValues()).ToArray());
             }
 
+            public KeyedList Remove(KeyedList other) {
+                KeyedList copy = DeepCopy();
+                other.keyedValues.ForEach(v => copy.SetValue(v.GetValue(), null));
+                return new KeyedList(copy.keyedValues.Where(k => k.Value != null).ToArray());
+            }
+
             public KeyedList Keys() => new KeyedList(keyedValues.Where(v => v.HasKey()).Select(v => GetStaticVariable(v.Key)).ToArray());
             public KeyedList Values() => new KeyedList(keyedValues.Select(v => v.Value).ToArray());
 

--- a/EasyCommands/Common/Collections.cs
+++ b/EasyCommands/Common/Collections.cs
@@ -34,6 +34,7 @@ namespace IngameScript {
                     case Return.NUMERIC:
                         return keyedValues[(int)CastNumber(key).GetTypedValue()];
                     case Return.STRING:
+                        var keyString = CastString(key).GetTypedValue();
                         return keyedValues.Where(v => v.Key == CastString(key).GetTypedValue())
                             .Cast<Variable>()
                             .DefaultIfEmpty(EmptyList())
@@ -59,6 +60,10 @@ namespace IngameScript {
             //TODO: Merge and then de-dupe keyed values (last wins?)
             public KeyedList Combine(KeyedList other) {
                 return new KeyedList(GetValues().Concat(other.GetValues()).ToArray());
+            }
+
+            public String Print() {
+                return "[" + string.Join(",", keyedValues.Select(k => (string.IsNullOrEmpty(k.Key) ? "" : k.Key + "=") + CastString(k.Value.GetValue()).GetTypedValue())) + "]";
             }
         }
     }

--- a/EasyCommands/Common/Collections.cs
+++ b/EasyCommands/Common/Collections.cs
@@ -64,6 +64,7 @@ namespace IngameScript {
             }
 
             public KeyedList Keys() => new KeyedList(keyedValues.Where(v => v.HasKey()).Select(v => GetStaticVariable(v.Key)).ToArray());
+            public KeyedList Values() => new KeyedList(keyedValues.Select(v => v.Value).ToArray());
 
             public KeyedList DeepCopy() => new KeyedList(keyedValues.Select(k => new KeyedVariable(k.Key, new StaticVariable(k.Value.GetValue().DeepCopy()))).ToArray());
 

--- a/EasyCommands/Common/Collections.cs
+++ b/EasyCommands/Common/Collections.cs
@@ -1,0 +1,65 @@
+﻿using Sandbox.Game.EntityComponents;
+using Sandbox.ModAPI.Ingame;
+using Sandbox.ModAPI.Interfaces;
+using SpaceEngineers.Game.ModAPI.Ingame;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+ using System.Linq;
+using System.Text;
+using VRage;
+using VRage.Collections;
+using VRage.Game;
+using VRage.Game.Components;
+using VRage.Game.GUI.TextPanel;
+using VRage.Game.ModAPI.Ingame;
+using VRage.Game.ModAPI.Ingame.Utilities;
+using VRage.Game.ObjectBuilders.Definitions;
+using VRageMath;
+
+namespace IngameScript {
+    partial class Program {
+        public class KeyedList {
+            List<KeyedVariable> keyedValues;
+
+            public KeyedList(params Variable[] values) {
+                keyedValues = values.ToList().ConvertAll(AsKeyedVariable);
+            }
+
+            public List<Variable> GetValues() => keyedValues.ConvertAll(v => (Variable)v);
+
+            //If numeric, get by index.  If string, get by key value
+            public Variable GetValue(Primitive key) {
+                switch(key.GetPrimitiveType()) {
+                    case Return.NUMERIC:
+                        return keyedValues[(int)CastNumber(key).GetTypedValue()];
+                    case Return.STRING:
+                        return keyedValues.Where(v => v.Key == CastString(key).GetTypedValue())
+                            .Cast<Variable>()
+                            .DefaultIfEmpty(EmptyList())
+                            .First();
+                    default:
+                        throw new Exception("Cannot lookup collection value by Primitive Type: " + key.GetPrimitiveType());
+                }
+            }
+
+            //If numeric, set by Index.  If string, put (or append) keyed value
+            public void SetValue(Primitive key, Variable value) {
+                if (key.GetPrimitiveType() == Return.NUMERIC) {
+                    keyedValues[(int)CastNumber(key).GetTypedValue()] = AsKeyedVariable(value);
+                } else if (key.GetPrimitiveType() == Return.STRING) {
+                    var keyString = CastString(key).GetTypedValue();
+                    KeyedVariable existing = keyedValues.Where(v => v.Key == keyString).FirstOrDefault();
+                    if (existing == null) {
+                        keyedValues.Add(new KeyedVariable(keyString, value));
+                    } else existing.Value = value;
+                } else throw new Exception("Cannot set collection value by Primitive Type: " + key.GetPrimitiveType());
+            }
+
+            //TODO: Merge and then de-dupe keyed values (last wins?)
+            public KeyedList Combine(KeyedList other) {
+                return new KeyedList(GetValues().Concat(other.GetValues()).ToArray());
+            }
+        }
+    }
+}

--- a/EasyCommands/Common/Collections.cs
+++ b/EasyCommands/Common/Collections.cs
@@ -64,7 +64,7 @@ namespace IngameScript {
             }
 
             public KeyedList Remove(KeyedList other) {
-                KeyedList copy = DeepCopy();
+                KeyedList copy = new KeyedList(keyedValues.Select(v => new KeyedVariable(v.Key, v.Value)).ToArray());
                 other.keyedValues.ForEach(v => copy.SetValue(v.GetValue(), null));
                 return new KeyedList(copy.keyedValues.Where(k => k.Value != null).ToArray());
             }

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -67,6 +67,7 @@ namespace IngameScript {
             AddBiOperation<KeyedList, object>(BiOperand.ADD, (a, b) => Combine(a, b));
             AddBiOperation<object, KeyedList>(BiOperand.ADD, (a, b) => Combine(a, b));
             AddBiOperation<float, float>(BiOperand.RANGE, (a, b) => new KeyedList(Enumerable.Range((int)a, (int)(b + 1 - a)).Select(i => GetStaticVariable(i)).ToArray()));
+            AddUniOperation<KeyedList>(UniOperand.KEYS, a => a.Keys());
 
             //Booleans
             AddUniOperation<bool>(UniOperand.NOT, a => !a);

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -64,9 +64,9 @@ namespace IngameScript {
 
         public void InitializeOperators() {
             //List
-            AddBiOperation<List<Variable>, object>(BiOperand.ADD, (a, b) => Combine(a, b));
-            AddBiOperation<object, List<Variable>>(BiOperand.ADD, (a, b) => Combine(a, b));
-            AddBiOperation<float, float>(BiOperand.RANGE, (a, b) => Enumerable.Range((int)a, (int)(b + 1 - a)).Select(i => GetStaticVariable(i)).ToList());
+            AddBiOperation<KeyedList, object>(BiOperand.ADD, (a, b) => Combine(a, b));
+            AddBiOperation<object, KeyedList>(BiOperand.ADD, (a, b) => Combine(a, b));
+            AddBiOperation<float, float>(BiOperand.RANGE, (a, b) => new KeyedList(Enumerable.Range((int)a, (int)(b + 1 - a)).Select(i => GetStaticVariable(i)).ToArray()));
 
             //Booleans
             AddUniOperation<bool>(UniOperand.NOT, a => !a);
@@ -134,7 +134,7 @@ namespace IngameScript {
         }
 
         static List<Variable> GetVariables(params object[] o) => o.ToList().Select(p => GetStaticVariable(p)).ToList();
-        static List<Variable> Combine(object a, object b) => AsList(ResolvePrimitive(a)).Concat(AsList(ResolvePrimitive(b))).ToList();
+        static KeyedList Combine(object a, object b) => AsList(ResolvePrimitive(a)).Combine(AsList(ResolvePrimitive(b)));
 
         static UniOperation SimpleUniOperand<T>(Func<T,object> resolver) {
             return (a) => {

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -68,6 +68,7 @@ namespace IngameScript {
             AddBiOperation<object, KeyedList>(BiOperand.ADD, (a, b) => Combine(a, b));
             AddBiOperation<float, float>(BiOperand.RANGE, (a, b) => new KeyedList(Enumerable.Range((int)a, (int)(b + 1 - a)).Select(i => GetStaticVariable(i)).ToArray()));
             AddUniOperation<KeyedList>(UniOperand.KEYS, a => a.Keys());
+            AddUniOperation<KeyedList>(UniOperand.VALUES, a => a.Values());
 
             //Booleans
             AddUniOperation<bool>(UniOperand.NOT, a => !a);

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -66,6 +66,7 @@ namespace IngameScript {
             //List
             AddBiOperation<KeyedList, object>(BiOperand.ADD, (a, b) => Combine(a, b));
             AddBiOperation<object, KeyedList>(BiOperand.ADD, (a, b) => Combine(a, b));
+            AddBiOperation<KeyedList, object>(BiOperand.SUBTACT, (a, b) => a.Remove(AsList(ResolvePrimitive(b))));
             AddBiOperation<float, float>(BiOperand.RANGE, (a, b) => new KeyedList(Enumerable.Range((int)a, (int)(b + 1 - a)).Select(i => GetStaticVariable(i)).ToArray()));
             AddUniOperation<KeyedList>(UniOperand.KEYS, a => a.Keys());
             AddUniOperation<KeyedList>(UniOperand.VALUES, a => a.Values());

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -71,7 +71,7 @@ namespace IngameScript {
             { typeof(double), Return.NUMERIC },
             { typeof(Vector3D), Return.VECTOR},
             { typeof(Color), Return.COLOR },
-            { typeof(List<Variable>), Return.LIST }
+            { typeof(KeyedList), Return.LIST }
         };
 
         static Dictionary<String, Color> colors = new Dictionary<String, Color>{
@@ -106,8 +106,8 @@ namespace IngameScript {
                 return new VectorPrimitive((Vector3D)o);
             } else if (o is Color) {
                 return new ColorPrimitive((Color)o);
-            } else if (o is List<Variable>) {
-                return new ListPrimitive((List<Variable>)o);
+            } else if (o is KeyedList) {
+                return new ListPrimitive((KeyedList)o);
             }
             else throw new Exception("Cannot convert type: " + o.GetType() + " to primitive");
         }
@@ -138,7 +138,7 @@ namespace IngameScript {
                 case Return.COLOR:
                     return new StringPrimitive(ColorToString(CastColor(p).GetTypedValue()));
                 case Return.LIST:
-                    return new StringPrimitive("[" + string.Join(",", CastList(p).GetTypedValue().Select(v => CastString(v.GetValue()).GetTypedValue())) + "]");
+                    return new StringPrimitive("[" + string.Join(",", CastList(p).GetTypedValue().GetValues().Select(v => CastString(v.GetValue()).GetTypedValue())) + "]");
                 default: return new StringPrimitive(p.GetValue().ToString());
             }
         }
@@ -171,7 +171,7 @@ namespace IngameScript {
         }
 
         public static ListPrimitive CastList(Primitive p) => new ListPrimitive(AsList(p));
-        public static List<Variable> AsList(Primitive p) => p.GetPrimitiveType() == Return.LIST ? (List<Variable>)p.GetValue() : new List<Variable> { GetStaticVariable(p.GetValue()) };
+        public static KeyedList AsList(Primitive p) => p.GetPrimitiveType() == Return.LIST ? (KeyedList)p.GetValue() : new KeyedList(GetStaticVariable(p.GetValue()));
 
         public static bool GetColor(String s, out Color color) {
             Color? possibleColor = null;
@@ -246,9 +246,9 @@ namespace IngameScript {
             public ColorPrimitive(Color color) : base(Return.COLOR, color) {}
         }
 
-        public class ListPrimitive : SimplePrimitive<List<Variable>> {
-            public ListPrimitive(List<Variable> list) : base(Return.LIST, list) { }
-            public override object GetDeepCopyValue() => GetTypedValue().Select(v => GetStaticVariable(v.GetValue().GetDeepCopyValue())).ToList();
+        public class ListPrimitive : SimplePrimitive<KeyedList> {
+            public ListPrimitive(KeyedList list) : base(Return.LIST, list) { }
+            public override object GetDeepCopyValue() => new KeyedList(GetTypedValue().GetValues().Select(v => GetStaticVariable(v.GetValue().GetDeepCopyValue())).ToArray());
         }
     }
 }

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -59,7 +59,7 @@ namespace IngameScript {
             }
 
             public Primitive DeepCopy() {
-                return ResolvePrimitive(this.GetDeepCopyValue());
+                return ResolvePrimitive(GetDeepCopyValue());
             }
         }
 
@@ -248,7 +248,7 @@ namespace IngameScript {
 
         public class ListPrimitive : SimplePrimitive<KeyedList> {
             public ListPrimitive(KeyedList list) : base(Return.LIST, list) { }
-            public override object GetDeepCopyValue() => new KeyedList(GetTypedValue().GetValues().Select(v => GetStaticVariable(v.GetValue().GetDeepCopyValue())).ToArray());
+            public override object GetDeepCopyValue() => GetTypedValue().DeepCopy();
         }
     }
 }

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -138,7 +138,7 @@ namespace IngameScript {
                 case Return.COLOR:
                     return new StringPrimitive(ColorToString(CastColor(p).GetTypedValue()));
                 case Return.LIST:
-                    return new StringPrimitive("[" + string.Join(",", CastList(p).GetTypedValue().GetValues().Select(v => CastString(v.GetValue()).GetTypedValue())) + "]");
+                    return new StringPrimitive(CastList(p).GetTypedValue().Print());
                 default: return new StringPrimitive(p.GetValue().ToString());
             }
         }

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -31,7 +31,7 @@ namespace IngameScript {
         public enum Function { GOTO, GOSUB, SWITCH }
         public enum Return { NUMERIC, BOOLEAN, STRING, VECTOR, COLOR, LIST }
         public enum BiOperand { ADD, SUBTACT, MULTIPLY, DIVIDE, MOD, AND, OR, COMPARE, DOT, EXPONENT, RANGE };
-        public enum UniOperand { NOT, ABS, SQRT, SIN, COS, TAN, ASIN, ACOS, ATAN, ROUND, KEYS };
+        public enum UniOperand { NOT, ABS, SQRT, SIN, COS, TAN, ASIN, ACOS, ATAN, ROUND, KEYS, VALUES };
         public enum LogLevel { TRACE, DEBUG, INFO, SCRIPT_ONLY }
         public enum PropertyAggregate { VALUE, SUM, COUNT, AVG, MIN, MAX };
         #endregion

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -31,7 +31,7 @@ namespace IngameScript {
         public enum Function { GOTO, GOSUB, SWITCH }
         public enum Return { NUMERIC, BOOLEAN, STRING, VECTOR, COLOR, LIST }
         public enum BiOperand { ADD, SUBTACT, MULTIPLY, DIVIDE, MOD, AND, OR, COMPARE, DOT, EXPONENT, RANGE };
-        public enum UniOperand { NOT, ABS, SQRT, SIN, COS, TAN, ASIN, ACOS, ATAN, ROUND };
+        public enum UniOperand { NOT, ABS, SQRT, SIN, COS, TAN, ASIN, ACOS, ATAN, ROUND, KEYS };
         public enum LogLevel { TRACE, DEBUG, INFO, SCRIPT_ONLY }
         public enum PropertyAggregate { VALUE, SUM, COUNT, AVG, MIN, MAX };
         #endregion

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -225,7 +225,6 @@ namespace IngameScript {
                 index = i;
             }
 
-            //TODO: Add Lookup by string support (Dictionary)
             public Primitive GetValue() {
                 var list = GetList();
                 var values = GetIndexValues()
@@ -265,6 +264,8 @@ namespace IngameScript {
                 Key = key;
                 Value = value;
             }
+
+            public bool HasKey() => !string.IsNullOrEmpty(Key);
 
             public Primitive GetValue() => Value.GetValue();
         }

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -229,8 +229,7 @@ namespace IngameScript {
             public Primitive GetValue() {
                 var list = GetList();
                 var values = GetIndexValues()
-                    .Where(i => i.GetPrimitiveType() == Return.NUMERIC)
-                    .Select(p => list[(int)CastNumber(p).GetTypedValue()])
+                    .Select(p => list.GetValue(p))
                     .ToList();
                 if (values.Count == 0) return expectedList.GetValue();
                 return values.Count == 1 ? values[0].GetValue() : new ListPrimitive(new KeyedList(values.ToArray()));
@@ -243,9 +242,9 @@ namespace IngameScript {
                 indexes.ForEach(index => list.SetValue(index, value));
             }
 
-            List<Variable> GetList() {
+            KeyedList GetList() {
                 Primitive list = expectedList.GetValue();
-                return list.GetPrimitiveType() == Return.LIST ? CastList(list).GetTypedValue().GetValues() : new List<Variable> { expectedList };
+                return list.GetPrimitiveType() == Return.LIST ? CastList(list).GetTypedValue() : new KeyedList(expectedList);
             }
 
             List<Primitive> GetIndexValues() {

--- a/EasyCommands/EasyCommands.csproj
+++ b/EasyCommands/EasyCommands.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Commands\Commands.cs" />
     <Compile Include="Commands\EntityProviders.cs" />
     <Compile Include="Common\Aggregators.cs" />
+    <Compile Include="Common\Collections.cs" />
     <Compile Include="Common\Items.cs" />
     <Compile Include="Common\Operations.cs" />
     <Compile Include="Common\Conditions.cs" />


### PR DESCRIPTION
This commit adds on to #93 by adding dictionary support.  Collections has been pulled into it's own primitive type which stores a list of optionally keyed values.

You can get or set values in a list by specifying a string variable instead of a numeric variable as the index.

You can also get a keyed sublist by asking for multiple string keys. 

I also added support for 2 new operations on lists, namely "keys" and "values", for retrieving just the keys or just the values from a keyed list (similar to dictionary).  Non-keyed values will not be returned by "keys", but all values are returned by "values".

Merging keyed lists de-dupes string based index values, keeping the only the keyed values from the 2nd list but otherwise maintaining the order.

It also adds new support for removing items from lists either by index (numeric) or by key (string).  Multiple items can be removed at once using lists, and numeric/string removal can be combined

This pull request implements #94 


