### PR TITLE
Selector list index enhancement

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -151,6 +151,7 @@
     <Compile Include="ScriptTests\SensorBlockTests.cs" />
     <Compile Include="ScriptTests\PistonBlockTests.cs" />
     <Compile Include="ScriptTests\ShipProximityTests.cs" />
+    <Compile Include="ScriptTests\SimpleSelectorTests.cs" />
     <Compile Include="ScriptTests\SimpleListTests.cs" />
     <Compile Include="ScriptTests\SorterBlockTests.cs" />
     <Compile Include="ScriptTests\TextSurfaceBlockTests.cs" />

--- a/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
@@ -40,6 +40,17 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         }
 
         [TestMethod]
+        public void ListIndexSelector() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on \"batteries\"[0]");
+            Assert.IsTrue(command is BlockCommand);
+            BlockCommand bc = (BlockCommand)command;
+            Assert.IsTrue(bc.entityProvider is IndexEntityProvider);
+            IndexEntityProvider iep = (IndexEntityProvider)bc.entityProvider;
+            Assert.AreEqual(0f, iep.index.GetValue().GetValue());
+        }
+
+        [TestMethod]
         public void InLineIndexSelector() {
             var program = MDKFactory.CreateProgram<Program>();
             var command = program.ParseCommand("turn on \"batteries\" @0");
@@ -91,6 +102,39 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             InMemoryVariable variable = (InMemoryVariable)sep.selector;
             Assert.AreEqual("a", variable.variableName);
             Assert.AreEqual(Block.SOUND, sep.blockType);
+        }
+
+        [TestMethod]
+        public void VariableSelectorWithIndex() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on the $mySirens[0]");
+            Assert.IsTrue(command is BlockCommand);
+            BlockCommand bc = (BlockCommand)command;
+            Assert.IsTrue(bc.entityProvider is IndexEntityProvider);
+            IndexEntityProvider iep = (IndexEntityProvider)bc.entityProvider;
+            Assert.AreEqual(0f, iep.index.GetValue().GetValue());
+            Assert.IsTrue(iep.provider is SelectorEntityProvider);
+            SelectorEntityProvider variableSelector = (SelectorEntityProvider)iep.provider;
+            Assert.IsTrue(variableSelector.selector is InMemoryVariable);
+            InMemoryVariable variable = (InMemoryVariable)variableSelector.selector;
+        }
+
+        [TestMethod]
+        public void VariableSelectorWithBlockTypeAndIndex() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("turn on the $mySirens sirens [0]");
+            Assert.IsTrue(command is BlockCommand);
+            BlockCommand bc = (BlockCommand)command;
+            Assert.IsTrue(bc.entityProvider is IndexEntityProvider);
+            IndexEntityProvider iep = (IndexEntityProvider)bc.entityProvider;
+            Assert.AreEqual(0f, iep.index.GetValue().GetValue());
+            Assert.IsTrue(iep.provider is SelectorEntityProvider);
+            SelectorEntityProvider variableSelector = (SelectorEntityProvider)iep.provider;
+            Assert.IsTrue(variableSelector.selector is InMemoryVariable);
+            InMemoryVariable variable = (InMemoryVariable)variableSelector.selector;
+            Assert.AreEqual("mySirens", variable.variableName);
+            Assert.IsTrue(variableSelector.isGroup);
+            Assert.AreEqual(Block.SOUND, variableSelector.blockType);
         }
 
         [TestMethod]

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
@@ -55,17 +55,6 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         }
 
         [TestMethod]
-        public void AssignVariableFromInMemoryVariableSelectorName() {
-            var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign $a to 2");
-            Assert.IsTrue(command is VariableAssignmentCommand);
-            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
-            Assert.AreEqual("a", assignCommand.variableName);
-            Assert.AreEqual(2, CastNumber(assignCommand.variable.GetValue()).GetTypedValue());
-            Assert.IsFalse(assignCommand.useReference);
-        }
-
-        [TestMethod]
         public void AssignVariableToAmbiguousStringValue() {
             var program = MDKFactory.CreateProgram<Program>();
             var command = program.ParseCommand("assign a to b");

--- a/EasyCommands.Tests/ScriptTests/LightBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/LightBlockTests.cs
@@ -115,9 +115,9 @@ turn on the ""hangar lights""
                 // with just one of the lights when we want to
                 var mockSingleLight = new Mock<IMyLightingBlock>();
                 var mockOtherLight = new Mock<IMyLightingBlock>();
-                test.MockBlocksOfType("single light", mockSingleLight);
-                test.MockBlocksOfType("other light", mockOtherLight);
                 test.MockBlocksInGroup("hangar lights", mockSingleLight, mockOtherLight);
+                test.MockBlocksOfType("other light", mockOtherLight);
+                test.MockBlocksOfType("single light", mockSingleLight);
 
                 test.RunUntilDone();
 

--- a/EasyCommands.Tests/ScriptTests/ScriptTest.cs
+++ b/EasyCommands.Tests/ScriptTests/ScriptTest.cs
@@ -22,8 +22,8 @@ namespace EasyCommands.Tests.ScriptTests
     class ScriptTest : IDisposable
     {
         public Program program;
+        public Mock<IMyProgrammableBlock> me;
         MockGridTerminalSystem mockGrid;
-        Mock<IMyProgrammableBlock> me;
         int entityIdCounter = 1000;
 
         /// <summary>
@@ -45,6 +45,7 @@ namespace EasyCommands.Tests.ScriptTests
             // And other required config for mocking
             mockGrid = new MockGridTerminalSystem();
             me = new Mock<IMyProgrammableBlock>();
+            MockBlocksOfType("Script Program", me);
 
             MDKFactory.ProgramConfig config = default;
             config.GridTerminalSystem = mockGrid;
@@ -140,8 +141,9 @@ namespace EasyCommands.Tests.ScriptTests
         /// <param name="blockMocks">The blocks being mocked and that will be returned later.</param>
         public void MockBlocksInGroup<T>(String groupName, params Mock<T>[] blockMocks) where T : class, IMyTerminalBlock
         {
-            foreach (Mock<T> block in blockMocks) {
-                block.Setup(x => x.EntityId).Returns(entityIdCounter++);
+            for(int i = 0; i < blockMocks.Length; i++ ) {
+                blockMocks[i].Setup(x => x.EntityId).Returns(entityIdCounter++);
+                blockMocks[i].Setup(x => x.CustomName).Returns(groupName + " " + i);
             }
 
             var mockGroup = new MockBlockGroup(groupName);
@@ -196,6 +198,8 @@ namespace EasyCommands.Tests.ScriptTests
                 blocks.ForEach(block => mockBlocks.Add(block));
             }
 
+            public List<IMyTerminalBlock> GetBlocks() => mockBlocks;
+
             public void GetBlocks(List<IMyTerminalBlock> blocks, Func<IMyTerminalBlock, bool> collect = null) {
                 blocks.AddRange(mockBlocks
                     .Where(block => collect == null ? true : collect(block))
@@ -230,8 +234,9 @@ namespace EasyCommands.Tests.ScriptTests
                 blocks.ForEach(block => mockBlocks.Add(block));
             }
 
-            public void AddGroup(IMyBlockGroup blockGroup) {
+            public void AddGroup(MockBlockGroup blockGroup) {
                 mockGroups.Add(blockGroup);
+                mockBlocks.UnionWith(blockGroup.GetBlocks());
             }
 
             public void GetBlockGroups(List<IMyBlockGroup> blockGroups, Func<IMyBlockGroup, bool> collect = null) {

--- a/EasyCommands/BlockHandlers/BlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/BlockHandlers.cs
@@ -240,6 +240,7 @@ namespace IngameScript {
             Direction GetDefaultDirection();
             List<Object> GetBlocks(Func<IMyTerminalBlock, bool> selector);
             List<Object> GetBlocksInGroup(String groupName);
+            String GetName(Object block);
 
             Primitive GetPropertyValue(Object block, PropertySupplier property);
             Primitive GetPropertyValue(Object block, PropertySupplier property, Direction direction);
@@ -308,7 +309,7 @@ namespace IngameScript {
                 return blocks;
             }
 
-            protected override string Name(T block) { return block.CustomName; }
+            public override string Name(T block) { return block.CustomName; }
 
             protected String GetCustomProperty(T block, String key) { return GetCustomData(block).GetValueOrDefault(key, null); }
             protected void SetCustomProperty(T block, String key, String value) {
@@ -337,9 +338,11 @@ namespace IngameScript {
 
             public List<Object> GetBlocks(Func<IMyTerminalBlock, bool> selector) { return GetBlocksOfType(selector).Select(t => t as object).ToList(); }
             public List<Object> GetBlocksInGroup(String groupName) { return GetBlocksOfTypeInGroup(groupName).Select(t => t as object).ToList(); }
+            public string GetName(object block) => Name((T)block);
 
             public abstract List<T> GetBlocksOfType(Func<IMyTerminalBlock, bool> selector);
             public abstract List<T> GetBlocksOfTypeInGroup(String name);
+            public abstract string Name(T block);
 
             public Direction GetDefaultDirection() {
                 if (!defaultDirection.HasValue) throw new Exception(GetType() + " Does Not Have a Default Direction");
@@ -360,34 +363,29 @@ namespace IngameScript {
                 return propertyHandlers[property.propertyType()].GetDirection((T)block, property, direction);
             }
             public void SetPropertyValue(Object block, PropertySupplier property, Primitive value) {
-                Debug("Setting " + Name(block) + " " + property + " to " + value.GetValue());
+                Debug("Setting " + GetName(block) + " " + property + " to " + value.GetValue());
                 propertyHandlers[property.propertyType()].Set((T)block, property, value);
             }
             public void SetPropertyValue(Object block, PropertySupplier property, Direction direction, Primitive value) {
-                Debug("Setting " + Name(block) + " " + property + " to " + value.GetValue() + " in " + direction + " direction");
+                Debug("Setting " + GetName(block) + " " + property + " to " + value.GetValue() + " in " + direction + " direction");
                 propertyHandlers[property.propertyType()].SetDirection((T)block, property, direction, value);
             }
             public void IncrementPropertyValue(Object block, PropertySupplier property, Primitive value) {
-                Debug("Incrementing " + Name(block) + " " + property + " by " + value.GetValue());
+                Debug("Incrementing " + GetName(block) + " " + property + " by " + value.GetValue());
                 propertyHandlers[property.propertyType()].Increment((T)block, property, value);
             }
             public void IncrementPropertyValue(Object block, PropertySupplier property, Direction direction, Primitive value) {
-                Debug("Incrementing " + Name(block) + " " + property + " by " + value.GetValue() + " in " + direction + " direction");
+                Debug("Incrementing " + GetName(block) + " " + property + " by " + value.GetValue() + " in " + direction + " direction");
                 propertyHandlers[property.propertyType()].IncrementDirection((T)block, property, direction, value);
             }
             public void MoveNumericPropertyValue(Object block, PropertySupplier property, Direction direction) {
-                Debug("Moving " + Name(block) + " " + property + " in " + direction + " direction");
+                Debug("Moving " + GetName(block) + " " + property + " in " + direction + " direction");
                 propertyHandlers[property.propertyType()].Move((T)block, property, direction);
             }
             public void ReverseNumericPropertyValue(Object block, PropertySupplier property) {
-                Debug("Reversing " + Name(block) + " " + property);
+                Debug("Reversing " + GetName(block) + " " + property);
                 propertyHandlers[property.propertyType()].Reverse((T)block, property);
             }
-
-            private string Name(object block) {
-                return Name((T)block);
-            }
-            protected abstract string Name(T block);
 
             protected void AddBooleanHandler(Property property, GetBooleanProperty<T> Get) {
                 AddBooleanHandler(property, Get, (b, v) => { });

--- a/EasyCommands/BlockHandlers/CargoBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/CargoBlockHandlers.cs
@@ -33,7 +33,7 @@ namespace IngameScript {
                 }
             }
 
-            protected override string Name(IMyInventory block) => block.Owner.DisplayName;
+            public override string Name(IMyInventory block) => block.Owner.DisplayName;
 
             PropertyHandler<IMyInventory> amountHandler = new PropertyHandler<IMyInventory> {
                 Get = (b, p) => {

--- a/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
+++ b/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
@@ -30,7 +30,7 @@ namespace IngameScript {
                 defaultDirection = Direction.UP;
             }
 
-            protected override string Name(IMyTextSurface block) {
+            public override string Name(IMyTextSurface block) {
                 return block.DisplayName;
             }
 

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -237,8 +237,8 @@ namespace IngameScript {
 
             //Register Special CommandParameter Output Values
             RegisterToString<GroupCommandParameter>(p => "group");
-            RegisterToString<StringCommandParameter>(p => "\"" + p.value + "\"");
-            RegisterToString<ExplicitStringCommandParameter>(p => "'" + p.value + "'");
+            RegisterToString<AmbiguiousStringCommandParameter>(p => "\"" + p.value + "\"");
+            RegisterToString<StringCommandParameter>(p => "'" + p.value + "'");
             RegisterToString<VariableAssignmentCommandParameter>(p => "Assign[name=" + p.variableName + ",global=" + p.isGlobal + ",ref=" + p.useReference + "]");
             RegisterToString<VariableCommandParameter>(p => "[Variable]");
             RegisterToString<VariableSelectorCommandParameter>(p => "[VariableSelector]");
@@ -300,11 +300,11 @@ namespace IngameScript {
             double numericValue;
 
             if (token.isExplicitString) {
-                commandParameters.Add(new ExplicitStringCommandParameter(token.original));
+                commandParameters.Add(new StringCommandParameter(token.original, true));
             } else if (token.isString) {
                 List<Token> subTokens = ParseTokens(t);
                 List<CommandParameter> subtokenParams = ParseCommandParameters(subTokens);
-                commandParameters.Add(new StringCommandParameter(token.original, false, subtokenParams.ToArray()));
+                commandParameters.Add(new AmbiguiousStringCommandParameter(token.original, false, subtokenParams.ToArray()));
             } else if (propertyWords.ContainsKey(t)) {
                 commandParameters.AddList(propertyWords[t]);
             } else if (Double.TryParse(t, out numericValue)) {
@@ -324,7 +324,7 @@ namespace IngameScript {
             } else if (t.StartsWith("$")) { //Variable References used as Selectors
                 commandParameters.Add(new VariableSelectorCommandParameter(new InMemoryVariable(token.original.Substring(1, token.original.Length - 1))));
             } else { //If nothing else matches, must be a string
-                commandParameters.Add(new StringCommandParameter(token.original, true));
+                commandParameters.Add(new AmbiguiousStringCommandParameter(token.original, true));
             }
 
             return commandParameters;

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -22,7 +22,7 @@ namespace IngameScript {
         //Internal (Don't touch!)
         Dictionary<String, List<CommandParameter>> propertyWords = new Dictionary<string, List<CommandParameter>>();
 
-        string[] separateTokens = new[] { "(", ")", "[", "]", ",", "+", "*", "/", "!", "^", "..", "%", ">", ">=", "<", "<=", "=", "==", "&", "&&", "|", "||"};
+        string[] separateTokens = new[] { "(", ")", "[", "]", ",", "+", "*", "/", "!", "^", "..", "%", ">", ">=", "<", "<=", "=", "==", "&", "&&", "|", "||", "@"};
 
         public void InitializeParsers() {
             //Ignored words that have no command parameters
@@ -168,6 +168,7 @@ namespace IngameScript {
             AddWords(Words("plus", "+"), new BiOperandTier2Operand(BiOperand.ADD));
             AddWords(Words("minus", "-"), new BiOperandTier2Operand(BiOperand.SUBTACT));
             AddWords(Words(".."), new BiOperandTier3Operand(BiOperand.RANGE));
+            AddWords(Words("@"), new IndexCommandParameter());
 
             //List Words
             AddWords(Words("["), new OpenBracketCommandParameter());
@@ -309,16 +310,6 @@ namespace IngameScript {
                 commandParameters.AddList(propertyWords[t]);
             } else if (Double.TryParse(t, out numericValue)) {
                 commandParameters.Add(new NumericCommandParameter((float)numericValue));
-            } else if (t.StartsWith("@")) {
-                if (t.Length == 1) commandParameters.Add(new IndexCommandParameter());
-                else {
-                    int indexValue;
-                    if (int.TryParse(t.Substring(1), out indexValue)) {
-                        commandParameters.Add(new IndexSelectorCommandParameter(new StaticVariable(new NumberPrimitive(indexValue))));
-                    } else {
-                        throw new Exception("Unable to parse index indicator: " + t);
-                    }
-                }
             } else if (t.StartsWith("{") && t.EndsWith("}")) { //Variable References
                 commandParameters.Add(new VariableCommandParameter(new InMemoryVariable(token.original.Substring(1, token.original.Length - 2))));
             } else if (t.StartsWith("$")) { //Variable References used as Selectors

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -71,10 +71,14 @@ namespace IngameScript {
                 requiredLeft<SelectorCommandParameter>(),
                 (p,selector) => new SelectorCommandParameter(new IndexEntityProvider(selector.GetValue().value,p.value))),
 
+            //ListProcessors
             new BranchingProcessor<ListCommandParameter> (
                 OneValueRule<ListCommandParameter, StringCommandParameter>(
                     requiredLeft<StringCommandParameter>(),
-                    (p, name) => new ListIndexCommandParameter(new ListIndexVariable(new InMemoryVariable(name.GetValue().value), p.value))),
+                    (list, name) => new ListIndexCommandParameter(new ListIndexVariable(new InMemoryVariable(name.GetValue().value), list.value))),
+                OneValueRule<ListCommandParameter, SelectorCommandParameter>(
+                    requiredLeft<SelectorCommandParameter>(),
+                    (list, selector) => new SelectorCommandParameter(new IndexEntityProvider(selector.GetValue().value, list.value))),
                 OneValueRule<ListCommandParameter, ListIndexCommandParameter>(
                     requiredLeft<ListIndexCommandParameter>(),
                     (list, index) => new ListIndexCommandParameter(new ListIndexVariable(index.GetValue().value, list.value))),

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -120,17 +120,21 @@ namespace IngameScript {
             public VariableSelectorCommandParameter(Variable value) : base(value) { }
         }
 
-        public class StringCommandParameter : ValueCommandParameter<String>, PrimitiveCommandParameter {
+        public class AmbiguiousStringCommandParameter : ValueCommandParameter<String>, PrimitiveCommandParameter {
             public List<CommandParameter> SubTokens = new List<CommandParameter>();
             public bool isImplicit;
-            public StringCommandParameter(String value, bool isImplicit, params CommandParameter[] SubTokens) : base(value) {
+            public AmbiguiousStringCommandParameter(String value, bool isImplicit, params CommandParameter[] SubTokens) : base(value) {
                 this.SubTokens = SubTokens.ToList();
                 this.isImplicit = isImplicit;
             }
         }
 
-        public class ExplicitStringCommandParameter : ValueCommandParameter<String>, PrimitiveCommandParameter {
-            public ExplicitStringCommandParameter(string value) : base(value) {}
+        public class StringCommandParameter : ValueCommandParameter<String>, PrimitiveCommandParameter {
+            public bool isExplicit;
+
+            public StringCommandParameter(string value, bool isExpl) : base(value) {
+                isExplicit = isExpl;
+            }
         }
 
         public class NumericCommandParameter : ValueCommandParameter<float>, PrimitiveCommandParameter {

--- a/EasyCommands/Commands/EntityProviders.cs
+++ b/EasyCommands/Commands/EntityProviders.cs
@@ -58,11 +58,23 @@ namespace IngameScript {
             public List<object> GetEntities() {
                 List<object> entities = provider.GetEntities();
                 List<object> selectedEntities = new List<Object>();
+                BlockHandler b = BlockHandlerRegistry.GetBlockHandler(GetBlockType());
 
-                //Return empty list if index > Count
-                int i = (int)CastNumber(index.GetValue()).GetTypedValue();
-                if (i < entities.Count) selectedEntities.Add(entities[i]);
+                var indexes = CastList(index.GetValue()).GetTypedValue().GetValues()
+                    .Select(v => v.GetValue()).ToList();
 
+                foreach (Primitive p in indexes) {
+                    //Return empty list if index > Count
+                    if (p.GetPrimitiveType() == Return.NUMERIC) {
+                        int i = (int)CastNumber(index.GetValue()).GetTypedValue();
+                        if (i < entities.Count) selectedEntities.Add(entities[i]);
+                    }
+                    if (p.GetPrimitiveType() == Return.STRING) {
+                        var entityName = CastString(p).GetTypedValue();
+                        selectedEntities.AddRange(entities.Where(o => entityName == b.GetName(o)));
+                    }
+                    //Other Index types not supported
+                }
                 return selectedEntities;
             }
         }

--- a/EasyCommands/Commands/EntityProviders.cs
+++ b/EasyCommands/Commands/EntityProviders.cs
@@ -66,7 +66,7 @@ namespace IngameScript {
                 foreach (Primitive p in indexes) {
                     //Return empty list if index > Count
                     if (p.GetPrimitiveType() == Return.NUMERIC) {
-                        int i = (int)CastNumber(index.GetValue()).GetTypedValue();
+                        int i = (int)CastNumber(p).GetTypedValue();
                         if (i < entities.Count) selectedEntities.Add(entities[i]);
                     }
                     if (p.GetPrimitiveType() == Return.STRING) {


### PR DESCRIPTION
This commit adds list index support to selectors so that you can fetch sub items by index from selectors.
numeric indexes act just like existing index selector where it looks for block list @ (index)
string indexes work by using the entity "name" as a filter.  This allows you to request that only blocks with a specific name in a specific group should do a thing.   You can also pass in a list of numeric+string indexes which will use blocks matching any of the numeric or string indexes.

Indexes can be specified with either the old format

``` "selector" @ index ``` , or with the list index format 
``` "selector" [index]```

It also refactors a little bit of how string command parameters are parsed which simplified some redundant parsing rules.

Lastly, it pulls up all selector parsing logic to the top of the parse tree, where it really belongs.

This pull request implements #96 