### PR TITLE
Combined Action and Assignment Command Parameters

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/BlockCommandProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/BlockCommandProcessorTests.cs
@@ -18,6 +18,13 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         }
 
         [TestMethod]
+        public void SimpleBlockCommandWithPropertyUsingAssign() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign the \"pistons\" height to 10");
+            Assert.IsTrue(command is BlockCommand);
+        }
+
+        [TestMethod]
         public void SimpleBlockCommandWithValueProperty() {
             var program = MDKFactory.CreateProgram<Program>();
             var command = program.ParseCommand("set the \"test cargo\" \"gold ingot\" amount to 0");

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
@@ -21,9 +21,32 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         }
 
         [TestMethod]
+        public void AssignVariableWithActionKeyword() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("set \"a\" to 2");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("a", assignCommand.variableName);
+            Assert.AreEqual(2, CastNumber(assignCommand.variable.GetValue()).GetTypedValue());
+            Assert.IsFalse(assignCommand.useReference);
+        }
+
+        [TestMethod]
         public void AssignGlobalVariable() {
             var program = MDKFactory.CreateProgram<Program>();
             var command = program.ParseCommand("assign global \"a\" to 2");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
+            Assert.AreEqual("a", assignCommand.variableName);
+            Assert.AreEqual(2, CastNumber(assignCommand.variable.GetValue()).GetTypedValue());
+            Assert.IsFalse(assignCommand.useReference);
+            Assert.IsTrue(assignCommand.isGlobal);
+        }
+
+        [TestMethod]
+        public void AssignGlobalVariableWithActionKeyword() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("set global \"a\" to 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
             Assert.AreEqual("a", assignCommand.variableName);

--- a/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleListTests.cs
@@ -115,6 +115,23 @@ Print ""After: "" + myList
         }
 
         [TestMethod]
+        public void AssignListIndexNewValueUsingSet() {
+            String script = @"
+:main
+set myList to [1,2,3,4]
+Print ""Before: "" + myList
+set myList[0] to 0
+Print ""After: "" + myList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: [1,2,3,4]"));
+                Assert.IsTrue(test.Logger.Contains("After: [0,2,3,4]"));
+            }
+        }
+
+        [TestMethod]
         public void AssignListKeyValue() {
             String script = @"
 :main

--- a/EasyCommands.Tests/ScriptTests/SimpleVariableTests.cs
+++ b/EasyCommands.Tests/ScriptTests/SimpleVariableTests.cs
@@ -37,5 +37,37 @@ Print ""b is: "" + b
                 Assert.IsTrue(test.Logger.Contains("b is: a1"));
             }
         }
+
+        [TestMethod]
+        public void AssignVariableWithSet() {
+            var script = @"
+set b to a + 1
+Print ""b is: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.program.logLevel = Program.LogLevel.INFO;
+
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("b is: a1"));
+            }
+        }
+
+        [TestMethod]
+        public void AssignGlobalVariableWithSet() {
+            var script = @"
+set global b to a + 1
+Print ""b is: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.program.logLevel = Program.LogLevel.INFO;
+
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("b is: a1"));
+            }
+        }
     }
 }

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -43,13 +43,15 @@ namespace IngameScript {
             AddWords(Words("counter", "counterclock", "counterclockwise"), new DirectionCommandParameter(Direction.COUNTERCLOCKWISE));
 
             //Action Words
-            AddWords(Words("move", "go", "tell", "turn", "rotate", "set"), new ActionCommandParameter());
-            AddWords(Words("increase", "raise", "extend", "expand"), new ActionCommandParameter(), new DirectionCommandParameter(Direction.UP));
-            AddWords(Words("add"), new ActionCommandParameter(), new RelativeCommandParameter(), new DirectionCommandParameter(Direction.UP));
-            AddWords(Words("subtact"), new ActionCommandParameter(), new RelativeCommandParameter(), new DirectionCommandParameter(Direction.DOWN));
-            AddWords(Words("decrease", "retract", "reduce"), new ActionCommandParameter(), new DirectionCommandParameter(Direction.DOWN));
+            AddWords(Words("bind", "tie", "link"), new AssignmentCommandParameter(true));
+            AddWords(Words("move", "go", "tell", "turn", "rotate", "set", "assign", "allocate", "designate"), new AssignmentCommandParameter());
+            AddWords(Words("increase", "raise", "extend", "expand"), new AssignmentCommandParameter(), new DirectionCommandParameter(Direction.UP));
+            AddWords(Words("add"), new AssignmentCommandParameter(), new RelativeCommandParameter(), new DirectionCommandParameter(Direction.UP));
+            AddWords(Words("subtact"), new AssignmentCommandParameter(), new RelativeCommandParameter(), new DirectionCommandParameter(Direction.DOWN));
+            AddWords(Words("decrease", "retract", "reduce"), new AssignmentCommandParameter(), new DirectionCommandParameter(Direction.DOWN));
             AddWords(Words("reverse"), new ReverseCommandParameter());
             AddWords(Words("by"), new RelativeCommandParameter());
+            AddWords(Words("global"), new GlobalCommandParameter());
 
             //Value Words
             AddWords(Words("on", "begin", "true", "start", "started", "resume", "resumed"), new BooleanCommandParameter(true));
@@ -107,9 +109,6 @@ namespace IngameScript {
             AddWords(Words("goto"), new FunctionCommandParameter(Function.GOTO));
             AddWords(Words("listen", "channel"), new ListenCommandParameter());
             AddWords(Words("send", "broadcast"), new SendCommandParameter());
-            AddWords(Words("assign", "allocate", "designate"), new AssignmentCommandParameter(false));
-            AddWords(Words("global"), new GlobalCommandParameter());
-            AddWords(Words("bind", "tie", "link"), new AssignmentCommandParameter(true));
             AddWords(Words("print", "log", "echo", "write"), new PrintCommandParameter());
             AddWords(Words("queue", "schedule"), new QueueCommandParameter(false));
             AddWords(Words("async", "background", "parallel"), new QueueCommandParameter(true));

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -114,7 +114,7 @@ namespace IngameScript {
                 requiredRight<ListIndexCommandParameter>(), requiredRight<VariableCommandParameter>(),
                 (p,list,variable) => new CommandReferenceParameter(new ListVariableAssignmentCommand(list.GetValue().value, variable.GetValue().value, p.useReference))),
 
-            //Primitive Procesor
+            //Primitive Processor
             new PrimitiveProcessor<PrimitiveCommandParameter>(),
 
             //ValuePropertyProcessor
@@ -779,7 +779,7 @@ namespace IngameScript {
         }
 
         static RuleProcessor<SelectorCommandParameter> BlockCommandProcessor() {
-            var actionProcessor = requiredEither<ActionCommandParameter>();
+            var assignmentProcessor = requiredEither<AssignmentCommandParameter>();
             var relativeProcessor = requiredEither<RelativeCommandParameter>();
             var variableProcessor = requiredEither<VariableCommandParameter>();
             var propertyProcessor = requiredEither<PropertyCommandParameter>();
@@ -787,7 +787,7 @@ namespace IngameScript {
             var reverseProcessor = requiredEither<ReverseCommandParameter>();
             var notProcessor = requiredEither<NotCommandParameter>();
             List<DataProcessor> processors = new List<DataProcessor> {
-                actionProcessor,
+                assignmentProcessor,
                 relativeProcessor,
                 variableProcessor,
                 propertyProcessor,
@@ -822,7 +822,7 @@ namespace IngameScript {
                 else if (AllSatisfied(relativeProcessor, directionProcessor)) blockAction = (b, e) => b.IncrementPropertyValue(e, propertySupplier(b), direction.value, variableSupplier().GetValue());
                 else if (AllSatisfied(relativeProcessor)) blockAction = (b, e) => b.IncrementPropertyValue(e, propertySupplier(b), variableSupplier().GetValue());
                 else if (AllSatisfied(variableProcessor, directionProcessor)) blockAction = (b, e) => b.SetPropertyValue(e, propertySupplier(b), direction.value, variableSupplier().GetValue());
-                else if (AllSatisfied(actionProcessor, directionProcessor)) blockAction = (b, e) => b.MoveNumericPropertyValue(e, propertySupplier(b), direction.value);
+                else if (AllSatisfied(assignmentProcessor, directionProcessor)) blockAction = (b, e) => b.MoveNumericPropertyValue(e, propertySupplier(b), direction.value);
                 else blockAction = (b, e) => b.SetPropertyValue(e, propertySupplier(b), variableSupplier().GetValue());
 
                 BlockCommand command = new BlockCommand(p.value, blockAction);

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -37,7 +37,6 @@ namespace IngameScript {
         public class ListSeparatorCommandParameter : SimpleCommandParameter { }
         public class CloseBracketCommandParameter : SimpleCommandParameter { }
         public class IteratorCommandParameter : SimpleCommandParameter { }
-        public class ActionCommandParameter : SimpleCommandParameter { }
         public class ReverseCommandParameter : SimpleCommandParameter { }
         public class RelativeCommandParameter : SimpleCommandParameter { }
         public class WaitCommandParameter : SimpleCommandParameter { }
@@ -95,7 +94,7 @@ namespace IngameScript {
         public class AssignmentCommandParameter : SimpleCommandParameter {
             public bool useReference;
 
-            public AssignmentCommandParameter(bool useReference) {
+            public AssignmentCommandParameter(bool useReference = false) {
                 this.useReference = useReference;
             }
         }


### PR DESCRIPTION
Having to remember to use "assign" instead of "set" when setting variables is annoying.  After moving Selector processing to the top of the parsing tree, it's now possible to combine "Action" and "Assignment".  Now you can set variables, list indexes, etc using "set" instead of "assign".  Conversely, you can initiate block commands using "assign", such as 'assign the "test pistons" height to 10'